### PR TITLE
Add basic FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ Yes it is!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Python Backend (FastAPI)
+
+A minimal FastAPI backend is provided in the `backend` directory. It exposes endpoints for uploading, cleaning and analyzing datasets.
+
+### Setup
+
+```bash
+# Install Python dependencies
+pip install -r backend/requirements.txt
+
+# Run the API server
+python backend/main.py
+```
+
+The API will start on `http://localhost:8000`. You can then interact with the routes such as `/upload`, `/clean`, `/goal`, `/analyze`, `/report/summary`, and `/export`.

--- a/backend/analytics.py
+++ b/backend/analytics.py
@@ -1,0 +1,25 @@
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_squared_error
+from typing import Any, Dict
+
+
+def analyze_goal(df: pd.DataFrame, goal: str) -> Dict[str, Any]:
+    """Very basic analytics based on goal type."""
+    if goal == 'descriptive':
+        summary = df.describe(include='all').to_dict()
+        return {"type": "descriptive", "summary": summary}
+    elif goal == 'predictive':
+        numeric_cols = df.select_dtypes(include=['number']).columns
+        if len(numeric_cols) < 2:
+            return {"error": "Not enough numeric data for prediction"}
+        X = df[numeric_cols[:-1]]
+        y = df[numeric_cols[-1]]
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+        model = LinearRegression().fit(X_train, y_train)
+        preds = model.predict(X_test)
+        mse = mean_squared_error(y_test, preds)
+        return {"type": "predictive", "mse": mse}
+    else:
+        return {"message": f"Goal '{goal}' not implemented"}

--- a/backend/cleaner.py
+++ b/backend/cleaner.py
@@ -1,0 +1,13 @@
+import pandas as pd
+
+
+def clean_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Simple cleaning logic: fill missing values and drop duplicates."""
+    cleaned = df.copy()
+    for col in cleaned.columns:
+        if cleaned[col].dtype == 'O':
+            cleaned[col].fillna('', inplace=True)
+        else:
+            cleaned[col].fillna(cleaned[col].mean(numeric_only=True), inplace=True)
+    cleaned.drop_duplicates(inplace=True)
+    return cleaned

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,78 @@
+from fastapi import FastAPI, File, UploadFile, Depends
+from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.middleware.cors import CORSMiddleware
+import pandas as pd
+from io import BytesIO
+
+from cleaner import clean_dataframe
+from analytics import analyze_goal
+
+app = FastAPI(title="SavvyClean Backend")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# In-memory storage for uploaded and cleaned data
+DATA_STORAGE = {}
+
+@app.post("/upload")
+async def upload(file: UploadFile = File(...)):
+    content = await file.read()
+    if file.filename.endswith('.csv'):
+        df = pd.read_csv(BytesIO(content))
+    elif file.filename.endswith('.xlsx'):
+        df = pd.read_excel(BytesIO(content))
+    elif file.filename.endswith('.txt'):
+        df = pd.read_csv(BytesIO(content), delimiter='\t')
+    else:
+        return JSONResponse({"error": "Unsupported file type"}, status_code=400)
+    DATA_STORAGE['raw'] = df
+    preview = df.head().to_dict(orient='records')
+    return {"filename": file.filename, "preview": preview, "columns": list(df.columns)}
+
+@app.post("/clean")
+async def clean():
+    df = DATA_STORAGE.get('raw')
+    if df is None:
+        return JSONResponse({"error": "No dataset uploaded"}, status_code=400)
+    cleaned = clean_dataframe(df)
+    DATA_STORAGE['clean'] = cleaned
+    return {"rows": len(cleaned), "columns": list(cleaned.columns)}
+
+@app.post("/goal")
+async def set_goal(goal: dict):
+    DATA_STORAGE['goal'] = goal.get('goal')
+    return {"message": "Goal received"}
+
+@app.post("/analyze")
+async def analyze():
+    df = DATA_STORAGE.get('clean')
+    goal = DATA_STORAGE.get('goal')
+    if df is None or goal is None:
+        return JSONResponse({"error": "Missing cleaned data or goal"}, status_code=400)
+    result = analyze_goal(df, goal)
+    DATA_STORAGE['analysis'] = result
+    return result
+
+@app.get("/report/summary")
+async def report_summary():
+    return DATA_STORAGE.get('analysis', {"summary": "No analysis available"})
+
+@app.post("/export")
+async def export():
+    df = DATA_STORAGE.get('clean')
+    if df is None:
+        return JSONResponse({"error": "No cleaned data"}, status_code=400)
+    output = BytesIO()
+    df.to_csv(output, index=False)
+    output.seek(0)
+    return StreamingResponse(output, media_type='text/csv', headers={'Content-Disposition': 'attachment; filename="cleaned.csv"'})
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+pandas
+pdfplumber
+openpyxl
+scikit-learn
+python-multipart
+joblib


### PR DESCRIPTION
## Summary
- add backend directory with FastAPI app
- implement simple data cleaner and analytics module
- document how to run the Python backend in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c3a2a1ef88324a0f7e5937caa581a