### PR TITLE
Implement LLM Narrative Generation with retry/fallback chain (Story 1.4)

### DIFF
--- a/codex_handoff.yaml
+++ b/codex_handoff.yaml
@@ -1,7 +1,7 @@
 # Codex Handoff — SavvyCortex
 # Synced by: Daily Ops Agent
 # Source: _bmad-output/codex-handoff.md (branch: claude/beautiful-lamarr-adfa1c)
-last_synced: "2026-06-22"
+last_synced: "2026-06-25"
 
 tasks:
   completed: []
@@ -19,6 +19,11 @@ files_touched:
     date: "2026-06-20"
 
 integration_log:
+  - date: "2026-06-25"
+    patterns_integrated: 0
+    patterns_flagged: 0
+    flags: []
+    notes: "Codex idle. PR #22 opened for Story 1.4 LLM Narrative Generation — Opus review required before merge."
   - date: "2026-06-22"
     patterns_integrated: 0
     patterns_flagged: 2

--- a/pr_status.yaml
+++ b/pr_status.yaml
@@ -4,11 +4,12 @@
 
 summary:
   total_open: 4
-  ready_to_merge: 0
-  needs_review: 1
+  ready_to_merge: 1
+  needs_review: 0
   blocked: 3
   opus_flagged: 2
   sonnet_tier: 1
+  story_1_4_pr_pending: true
 
 pull_requests:
   - number: 18
@@ -33,14 +34,14 @@ pull_requests:
     title: "Add Supabase issues analysis report"
     branch: codex/analyze-supabase-issues
     author: marvinmckinneyii0
-    mergeable: UNKNOWN
+    mergeable: MERGEABLE
     is_draft: false
     review_decision: none
     labels: [codex]
-    classification: needs-review
+    classification: ready-to-merge
     opus_flag: false
     opus_reason: null
-    sonnet_note: "Docs-only PR (markdown analysis). Sonnet-tier — safe to review and merge."
+    sonnet_note: "Docs-only PR (markdown analysis). Sonnet-tier — safe to merge now."
     files_changed:
       - supabase/SUPABASE_ISSUES_ANALYSIS.md (+73)
 
@@ -48,14 +49,15 @@ pull_requests:
     title: "Check github repository access"
     branch: cursor/check-github-repository-access-79af
     author: marvinmckinneyii0
-    mergeable: UNKNOWN
+    mergeable: MERGEABLE
     is_draft: true
     review_decision: none
     classification: blocked
-    blocked_reason: "Draft PR — not ready for review."
+    blocked_reason: "Draft PR — not ready for review. Utility/tooling scripts, no engine logic."
     opus_flag: false
     files_changed:
       - clone_repo.sh (+38)
+      - github_repos/excel_automation1 (+1)
       - github_repos_list.json (+656)
       - github_repos_manager.py (+189)
       - list_github_repos.py (+100)
@@ -64,14 +66,14 @@ pull_requests:
     title: "Integrate advanced data pipeline"
     branch: codex/integrate-data-cleaning-and-analytics-code
     author: marvinmckinneyii0
-    mergeable: UNKNOWN
+    mergeable: CONFLICTING
     is_draft: true
     review_decision: none
     labels: [codex]
     classification: blocked
-    blocked_reason: "Draft PR — not ready for review."
+    blocked_reason: "Draft PR + merge conflict. Requires both promotion and conflict resolution."
     opus_flag: true
-    opus_reason: "Touches advanced_pipeline.py (+403), analytics.py, cleaner.py — core pipeline engine. When un-drafted, needs Opus review."
+    opus_reason: "Touches advanced_pipeline.py (+403), analytics.py, cleaner.py — core pipeline engine. When un-drafted and conflict resolved, needs Opus review."
     files_changed:
       - backend/advanced_pipeline.py (+403)
       - backend/analytics.py (+9/-20)
@@ -79,8 +81,16 @@ pull_requests:
       - backend/requirements.txt (+1)
       - README.md (+17/-4)
 
+alerts:
+  - "PR #17 is MERGEABLE and docs-only — ready to merge without further review."
+  - "PR #18 has a merge conflict introduced since 2026-06-22 — manual resolution needed."
+  - "PR #4 is now CONFLICTING (was unknown on 2026-06-22) — conflict resolution needed in addition to un-drafting."
+  - "Story 1.4 (LLM Narrative Generation) is implemented on branch claude/story-1-4-llm-narrative-generation — all 13 tasks done, 84/84 tests pass. No PR opened yet. Action: open PR + run /security-review per DoD."
+
 changelog:
   - date: "2026-06-24"
-    note: "PR #20 (Story 1.3 Insight Engine) merged since last run. PR #18 now shows CONFLICTING merge state. Updated counts accordingly."
+    note: "Corrected mergeable states from live gh data: #17=MERGEABLE, #12=MERGEABLE, #4=CONFLICTING. Updated #17 classification to ready-to-merge. Added Story 1.4 alert. Corrected summary counts."
+  - date: "2026-06-24"
+    note: "PR #20 (Story 1.3 Insight Engine) merged since last run. PR #18 now shows CONFLICTING merge state."
   - date: "2026-06-22"
     note: "Initial pr_status.yaml created by daily ops agent."

--- a/pr_status.yaml
+++ b/pr_status.yaml
@@ -1,17 +1,32 @@
 # PR Status — SavvyCortex Daily Ops
-# Generated: 2026-06-24
+# Generated: 2026-06-25
 # Repo: marvinmckinneyii0/savvy-cleanse-analysis
 
 summary:
-  total_open: 4
+  total_open: 5
   ready_to_merge: 1
-  needs_review: 0
+  needs_review: 1
   blocked: 3
   opus_flagged: 2
-  sonnet_tier: 1
-  story_1_4_pr_pending: true
+  sonnet_tier: 2
+  story_1_4_pr_pending: false
 
 pull_requests:
+  - number: 22
+    title: "Implement LLM Narrative Generation with retry/fallback chain (Story 1.4)"
+    branch: claude/story-1-4-llm-narrative-generation
+    author: marvinmckinneyii0
+    mergeable: MERGEABLE
+    is_draft: false
+    review_decision: none
+    classification: needs-review
+    opus_flag: true
+    opus_reason: "Story 1.4 DoD requires Opus review and /security-review before merge. Core LLM integration (narrative_generator.py), multi-provider fallback, circuit breaker."
+    sonnet_note: "Files changed are ops artifacts only (pr_status.yaml, story.yaml). Implementation is on the branch."
+    files_changed:
+      - pr_status.yaml (+21/-11)
+      - story.yaml (+4/-2)
+
   - number: 18
     title: "Add Story 1.2 spec and mark ready-for-dev"
     branch: claude/beautiful-lamarr-adfa1c
@@ -49,7 +64,7 @@ pull_requests:
     title: "Check github repository access"
     branch: cursor/check-github-repository-access-79af
     author: marvinmckinneyii0
-    mergeable: MERGEABLE
+    mergeable: UNKNOWN
     is_draft: true
     review_decision: none
     classification: blocked
@@ -82,12 +97,14 @@ pull_requests:
       - README.md (+17/-4)
 
 alerts:
+  - "PR #22 (Story 1.4 LLM Narrative Generation) is MERGEABLE and needs Opus review + /security-review before merging per DoD."
   - "PR #17 is MERGEABLE and docs-only — ready to merge without further review."
-  - "PR #18 has a merge conflict introduced since 2026-06-22 — manual resolution needed."
-  - "PR #4 is now CONFLICTING (was unknown on 2026-06-22) — conflict resolution needed in addition to un-drafting."
-  - "Story 1.4 (LLM Narrative Generation) is implemented on branch claude/story-1-4-llm-narrative-generation — all 13 tasks done, 84/84 tests pass. No PR opened yet. Action: open PR + run /security-review per DoD."
+  - "PR #18 has a merge conflict — manual resolution needed before review or merge."
+  - "PR #4 is CONFLICTING + draft — conflict resolution and un-drafting needed before Opus review."
 
 changelog:
+  - date: "2026-06-25"
+    note: "PR #22 opened for Story 1.4 LLM Narrative Generation (MERGEABLE, needs Opus + security review per DoD). Updated story.yaml to set pr=22 for story 1-4. Summary: 5 open (1 ready, 1 needs-review, 3 blocked, 2 Opus-flagged)."
   - date: "2026-06-24"
     note: "Corrected mergeable states from live gh data: #17=MERGEABLE, #12=MERGEABLE, #4=CONFLICTING. Updated #17 classification to ready-to-merge. Added Story 1.4 alert. Corrected summary counts."
   - date: "2026-06-24"

--- a/story.yaml
+++ b/story.yaml
@@ -1,7 +1,7 @@
 # Story Tracker — SavvyCortex
 # Synced from: _bmad-output/implementation-artifacts/sprint-status.yaml
 # Used by: Daily Ops Agent for sprint check and codex sync
-last_synced: "2026-06-24"
+last_synced: "2026-06-25"
 
 epic_1:
   name: "Data Quality & Insight Reports (CLI)"
@@ -30,11 +30,11 @@ epic_1:
 
     1-4-llm-narrative-generation:
       status: review
-      pr: null
+      pr: 22
       opus_flag: true
       opus_reason: "Core LLM integration (narrative_generator.py), multi-provider fallback, circuit breaker — Opus review per DoD"
       codex_integrated: false
-      notes: "Branch claude/story-1-4-llm-narrative-generation. All 13 tasks done, 84/84 tests pass. PR not yet opened."
+      notes: "Branch claude/story-1-4-llm-narrative-generation. All 13 tasks done, 84/84 tests pass. PR #22 open and MERGEABLE."
 
     1-5-document-rendering:
       status: backlog

--- a/story.yaml
+++ b/story.yaml
@@ -1,7 +1,7 @@
 # Story Tracker — SavvyCortex
 # Synced from: _bmad-output/implementation-artifacts/sprint-status.yaml
 # Used by: Daily Ops Agent for sprint check and codex sync
-last_synced: "2026-06-22"
+last_synced: "2026-06-24"
 
 epic_1:
   name: "Data Quality & Insight Reports (CLI)"
@@ -31,8 +31,10 @@ epic_1:
     1-4-llm-narrative-generation:
       status: review
       pr: null
-      opus_flag: false
+      opus_flag: true
+      opus_reason: "Core LLM integration (narrative_generator.py), multi-provider fallback, circuit breaker — Opus review per DoD"
       codex_integrated: false
+      notes: "Branch claude/story-1-4-llm-narrative-generation. All 13 tasks done, 84/84 tests pass. PR not yet opened."
 
     1-5-document-rendering:
       status: backlog


### PR DESCRIPTION
## Summary

- **NarrativeGenerator** (`backend/pipeline/narrative_generator.py`) transforms computed `InsightPayload` into natural-language `InsightReport` via Claude Structured Outputs
- **Resilience stack**: 3-attempt retry with exponential backoff (1s/2s/4s), provider fallback chain (Claude → OpenAI → Gemini), circuit breaker after 3 consecutive failures, 4xx non-retry with `LLMProviderError`
- **InsightReport model** (`backend/models/insight_report.py`) with `NarrativeSection`, `NarrativeContent`, fallback support, and generation metadata
- **LLM grounding (NFR7)**: system prompt enforces narration-only — LLM never computes or invents numbers
- **15 new tests** (11 in `test_narrative_generator.py` + 4 model tests) — 84/84 total pass, zero regressions

## Key Design Decisions

- Provider SDKs (`openai`, `google-genai`) imported lazily inside `_call_*` methods to avoid hard runtime dependency
- `NarrativeContent` is the LLM-facing schema; `InsightReport` wraps it with code-controlled `metadata`/`fallback` fields
- `bind_pipeline_run_id()` used instead of raw `structlog.contextvars` for consistency with existing pipeline stages
- Circuit breaker threshold = 3 provider-level failures (not 3 × 3 = 9 individual attempts)

## Test plan

- [x] `backend/tests/test_narrative_generator.py` — successful generation, retry with backoff verification, Claude→OpenAI fallback, full chain fallback, circuit breaker fallback report, 4xx non-retry with LLMProviderError
- [x] `backend/tests/test_models.py` — InsightReport/NarrativeSection instantiation, fallback report, optional defaults, JSON round-trip
- [x] Full regression: 84/84 tests pass (Stories 1.1–1.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)