### PR TITLE
fix(security): remove client-side xlsx (SheetJS), move spreadsheet parse server-side (#24)

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,10 @@
+"""Backend HTTP API layer (Presentation tier).
+
+Currently hosts a single endpoint — the server-side spreadsheet parser that
+replaced the removed client-side SheetJS dependency. Epic 3 (Phase 3 — Web
+Application) will expand this package into the full customer/admin API surface;
+until then it deliberately stays minimal.
+
+Per the three-layer separation in architecture.md, modules here may import from
+``pipeline`` / ``models`` but never the reverse.
+"""

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -1,0 +1,30 @@
+"""Minimal FastAPI host for the parse endpoint.
+
+This is a deliberately small application that exists so the server-side parser
+introduced by the SheetJS migration is actually runnable today. The legacy
+``backend/main.py`` and ``backend/main_enhanced.py`` are off-limits to new code
+(see their STATUS headers), and the full web backend is Epic 3 (Phase 3). When
+that arrives it will own application assembly; this module folds into it.
+
+Run locally::
+
+    uvicorn backend.api.app:app --port 8000
+
+The Vite dev server proxies ``/api`` here (see ``vite.config.ts``), so the
+browser talks to it same-origin and no CORS configuration is required in dev.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from backend.api.parse_file import router as parse_router
+
+app = FastAPI(title="SavvyCortex API", version="0.1.0")
+app.include_router(parse_router)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Liveness probe for local dev and the Vite proxy."""
+    return {"status": "ok"}

--- a/backend/api/parse_file.py
+++ b/backend/api/parse_file.py
@@ -1,0 +1,248 @@
+"""Server-side spreadsheet parse endpoint — ``POST /api/parse-file``.
+
+This module is the backend half of the SheetJS → server-side migration. The
+frontend formerly parsed ``.xlsx`` in the browser via the ``xlsx`` (SheetJS)
+package, which carried two unpatched HIGH advisories (GHSA-4r6h-8v6p-xvw6
+prototype pollution, GHSA-5pgg-2g8v-p4x9 ReDoS). That package was removed; the
+browser now POSTs the raw file here and receives a typed
+:class:`~backend.models.parsed_file.ParsedFileResponse`.
+
+Why openpyxl directly, not ``pandas.read_excel``
+------------------------------------------------
+``pandas.read_excel`` is a convenience wrapper that silently coerces dtypes,
+fills NaN, and infers types before the data is ever inspected — it *fixes*
+before it *detects*. That is precisely backwards for a data-quality platform.
+We instead drive :func:`openpyxl.load_workbook` and own the cell-iteration loop,
+so null cells survive as ``None``, dates serialise losslessly to ISO 8601, and
+anything we cannot represent faithfully (an Excel error literal, a formula with
+no cached result) is surfaced as a structured parse error rather than mutated.
+
+Two-pass read
+-------------
+``data_only=True`` returns a formula's *cached result* but erases the fact that
+the cell was ever a formula. To still flag a formula whose result is missing
+(workbook never recalculated) we read the workbook twice: once with
+``data_only=False`` to learn which cells are formulas, once with
+``data_only=True`` to read their computed values. Both passes are ``read_only``
+to keep memory bounded on large sheets.
+
+Scope: openpyxl reads the OOXML formats (``.xlsx`` / ``.xlsm``) only. The legacy
+binary ``.xls`` (BIFF) format is rejected with a 400 — it would need a separate
+reader and is handled as an explicit product decision, not a silent fallback.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from io import BytesIO
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from openpyxl import load_workbook
+from openpyxl.worksheet._read_only import ReadOnlyWorksheet
+
+from backend.models.parsed_file import CellParseError, ParsedFileResponse
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api", tags=["parse"])
+
+# openpyxl reads OOXML only. ``.xls`` (legacy BIFF) is intentionally excluded.
+_SUPPORTED_EXTENSIONS = frozenset({"xlsx", "xlsm"})
+
+
+class SpreadsheetParseError(Exception):
+    """Raised when a workbook cannot be read or contains no usable data.
+
+    Carries a user-facing message; the route maps it to an HTTP 400 so the
+    frontend can surface it the same way the former client-side parser did.
+    """
+
+
+def _extension(filename: str | None) -> str:
+    """Return the lowercased extension of *filename*, or ``""`` if none."""
+    if not filename or "." not in filename:
+        return ""
+    return filename.rsplit(".", 1)[-1].lower()
+
+
+def _map_formulas(ws: ReadOnlyWorksheet) -> dict[tuple[int, int], str]:
+    """Map ``(row, column)`` → formula string for every formula cell.
+
+    Read from the ``data_only=False`` pass, where a formula cell's
+    ``data_type`` is ``"f"`` and its value is the formula text. Used to flag
+    formulas whose cached result is absent in the value pass.
+    """
+    formulas: dict[tuple[int, int], str] = {}
+    for row in ws.iter_rows():
+        for cell in row:
+            if cell.value is not None and cell.data_type == "f":
+                formulas[(cell.row, cell.column)] = str(cell.value)
+    return formulas
+
+
+def _row_number(cells: Any, fallback: int) -> int:
+    """Return the 1-based sheet row for a row of cells.
+
+    In read-only mode, blank padding cells are shared ``EmptyCell`` sentinels
+    with no coordinates, so we read the row index off the first real cell and
+    fall back to a positional estimate if the whole row is empty.
+    """
+    for cell in cells:
+        row = getattr(cell, "row", None)
+        if row is not None:
+            return row
+    return fallback
+
+
+def _cell_value(
+    cell: Any,
+    formula_map: dict[tuple[int, int], str],
+    column: str,
+    row_number: int,
+    errors: list[CellParseError],
+) -> Any:
+    """Convert one openpyxl cell to a JSON-safe value, recording any issue.
+
+    Preserves nulls as ``None`` (never ``""``), serialises temporal values to
+    ISO 8601, emits ``None`` for Excel error literals and missing-result
+    formulas while appending a :class:`CellParseError` for each. Numbers,
+    strings, and booleans pass through unchanged.
+    """
+    if cell is None:
+        return None
+
+    # Excel error literal (#REF!, #N/A, #DIV/0!, ...). Surface, do not coerce.
+    if getattr(cell, "data_type", None) == "e":
+        errors.append(
+            CellParseError(
+                row=row_number, column=column, issue="error_cell", raw_value=str(cell.value)
+            )
+        )
+        return None
+
+    value = cell.value
+
+    if value is None:
+        # Empty cell, or a formula whose cached result was never computed. The
+        # former is valid data (preserved as null); only the latter is flagged.
+        # Read-only blank cells are coordinateless EmptyCells — they can never
+        # be formulas, so a missing coordinate simply means "ordinary null".
+        cell_row = getattr(cell, "row", None)
+        cell_col = getattr(cell, "column", None)
+        formula = (
+            formula_map.get((cell_row, cell_col))
+            if cell_row is not None and cell_col is not None
+            else None
+        )
+        if formula is not None:
+            errors.append(
+                CellParseError(
+                    row=row_number, column=column, issue="formula_cell", raw_value=formula
+                )
+            )
+        return None
+
+    # Temporal cells arrive as Python datetime/date/time; ISO 8601 round-trips
+    # losslessly and is unambiguous across the wire.
+    if isinstance(value, (datetime, date, time)):
+        return value.isoformat()
+
+    return value
+
+
+def parse_spreadsheet(content: bytes, file_type: str) -> ParsedFileResponse:
+    """Parse OOXML spreadsheet *content* into a :class:`ParsedFileResponse`.
+
+    Pure function (no HTTP) so it is unit-testable in isolation. The first row
+    is treated as the header row, matching the prior client-side behaviour;
+    blank header cells become ``"Column N"``. Raises
+    :class:`SpreadsheetParseError` on an unreadable or empty workbook.
+    """
+    try:
+        wb_formulas = load_workbook(BytesIO(content), data_only=False, read_only=True)
+        wb_values = load_workbook(BytesIO(content), data_only=True, read_only=True)
+    except Exception as exc:  # openpyxl raises a variety of types on bad input
+        raise SpreadsheetParseError(
+            f"Could not read spreadsheet: {exc}"
+        ) from exc
+
+    try:
+        if not wb_formulas.worksheets or not wb_values.worksheets:
+            raise SpreadsheetParseError("Spreadsheet contains no worksheets.")
+
+        formula_map = _map_formulas(wb_formulas.worksheets[0])
+        ws = wb_values.worksheets[0]
+
+        rows_iter = ws.iter_rows()
+        header_cells = next(rows_iter, None)
+        if header_cells is None:
+            raise SpreadsheetParseError("Spreadsheet appears to be empty.")
+
+        headers: list[str] = []
+        for idx, cell in enumerate(header_cells):
+            raw = cell.value
+            headers.append(str(raw) if raw not in (None, "") else f"Column {idx + 1}")
+
+        header_row = _row_number(header_cells, 1)
+
+        errors: list[CellParseError] = []
+        rows: list[list[Any]] = []
+        for offset, row_cells in enumerate(rows_iter):
+            row_number = _row_number(row_cells, header_row + 1 + offset)
+            row_values = [
+                _cell_value(
+                    row_cells[i] if i < len(row_cells) else None,
+                    formula_map,
+                    headers[i],
+                    row_number,
+                    errors,
+                )
+                for i in range(len(headers))
+            ]
+            rows.append(row_values)
+
+        return ParsedFileResponse(
+            headers=headers,
+            rows=rows,
+            total_rows=len(rows),
+            file_type=file_type,
+            parse_errors=errors,
+        )
+    finally:
+        wb_formulas.close()
+        wb_values.close()
+
+
+@router.post("/parse-file", response_model=ParsedFileResponse)
+async def parse_file(file: UploadFile = File(...)) -> ParsedFileResponse:
+    """Parse an uploaded ``.xlsx`` / ``.xlsm`` file into structured rows.
+
+    Returns 400 for unsupported extensions (including legacy ``.xls``) and for
+    workbooks that cannot be read.
+    """
+    file_type = _extension(file.filename)
+    if file_type not in _SUPPORTED_EXTENSIONS:
+        detail = (
+            f"Unsupported file type for server-side parse: "
+            f"'{file_type or 'unknown'}'. This endpoint handles .xlsx and .xlsm; "
+            f"legacy .xls is not supported."
+        )
+        raise HTTPException(status_code=400, detail=detail)
+
+    content = await file.read()
+    try:
+        result = parse_spreadsheet(content, file_type)
+    except SpreadsheetParseError as exc:
+        logger.warning("parse_file.rejected", filename=file.filename, reason=str(exc))
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    logger.info(
+        "parse_file.parsed",
+        filename=file.filename,
+        rows=result.total_rows,
+        columns=len(result.headers),
+        parse_errors=len(result.parse_errors),
+    )
+    return result

--- a/backend/models/parsed_file.py
+++ b/backend/models/parsed_file.py
@@ -1,0 +1,80 @@
+"""ParsedFile Pydantic models — server-side file-parse output contract.
+
+The :class:`ParsedFileResponse` is produced by the file-parse endpoint
+(``POST /api/parse-file``, see :mod:`backend.api.parse_file`) and consumed by
+the frontend upload utility (``src/utils/fileParser.ts``). It is the typed
+boundary that replaced the former client-side SheetJS (``xlsx``) parse, which
+was removed to clear two HIGH advisories (GHSA-4r6h-8v6p-xvw6 prototype
+pollution, GHSA-5pgg-2g8v-p4x9 ReDoS).
+
+Why a dedicated contract
+------------------------
+Spreadsheet parsing now runs on the backend with ``openpyxl`` reading cells
+directly — deliberately NOT through ``pandas.read_excel``, which silently
+coerces types and fills nulls before the data is ever inspected. That would
+violate the platform's detect-don't-fix constraint. This model is the shape
+that crosses the wire after our own cell-iteration loop has run; it preserves
+nulls as JSON ``null`` and records anything it could not represent faithfully
+in :attr:`ParsedFileResponse.parse_errors` rather than dropping or coercing it.
+
+The field shape intentionally mirrors the frontend ``ParsedData`` TypeScript
+interface (``headers`` / ``rows`` / ``total_rows`` / ``file_type``) so the
+client maps the response with a trivial rename. :attr:`parse_errors` is
+additive — older consumers that ignore it remain valid.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+# The set of conditions the cell-iteration loop surfaces instead of silently
+# coercing. Kept as a Literal so an unexpected issue string fails validation
+# at the contract boundary rather than leaking to the frontend.
+#
+# Note what is NOT here: a plain empty cell is not an error. Nulls are valid
+# data — they are preserved as ``None`` in :attr:`ParsedFileResponse.rows` and
+# left for the downstream completeness check to assess. Flagging every blank
+# cell would drown the genuine signals below.
+#
+#   formula_cell -- a formula whose cached result was absent (workbook never
+#                   recalculated), so no value could be read. raw_value holds
+#                   the formula string.
+#   error_cell   -- an Excel error literal (#REF!, #N/A, #DIV/0!, ...). The
+#                   value is emitted as None; raw_value holds the error text.
+CellIssueType = Literal[
+    "formula_cell",
+    "error_cell",
+]
+
+
+class CellParseError(BaseModel):
+    """A single cell the parser could not represent faithfully.
+
+    Emitted instead of mutating the value. ``raw_value`` is always the
+    stringified original (``str(cell.value)``) so the payload is JSON-safe
+    regardless of the offending cell's underlying type, and so the downstream
+    DQA layer can surface the exact source value to the user.
+    """
+
+    row: int = Field(..., description="1-based row index in the source sheet.")
+    column: str = Field(..., description="Header name, or column letter when headerless.")
+    issue: CellIssueType
+    raw_value: str = Field(..., description="str() of the original cell value.")
+
+
+class ParsedFileResponse(BaseModel):
+    """Typed result of a server-side file parse.
+
+    Mirrors the frontend ``ParsedData`` interface. ``rows`` is jagged-safe
+    (each inner list aligns to ``headers`` by position) and preserves nulls as
+    ``None`` — never the empty string. Clean files carry an empty
+    ``parse_errors`` list.
+    """
+
+    headers: list[str]
+    rows: list[list[Any]]
+    total_rows: int
+    file_type: str
+    parse_errors: list[CellParseError] = Field(default_factory=list)

--- a/backend/tests/test_parse_file.py
+++ b/backend/tests/test_parse_file.py
@@ -1,0 +1,199 @@
+"""Tests for the server-side spreadsheet parser (SheetJS migration).
+
+Covers the pure :func:`parse_spreadsheet` function and the HTTP route. Fixtures
+build ``.xlsx`` bytes in memory with openpyxl — no test files on disk.
+
+A note on formula cells: openpyxl writes formulas but never evaluates them, so
+a workbook produced here has no cached result. That deterministically exercises
+the "formula result missing → parse_errors entry" branch, which is exactly the
+contract the frontend relies on.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from io import BytesIO
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from openpyxl import Workbook
+
+from backend.api.app import app
+from backend.api.parse_file import SpreadsheetParseError, parse_spreadsheet
+
+
+def _xlsx_bytes(rows: list[list[Any]]) -> bytes:
+    """Serialise *rows* (first row = headers) into ``.xlsx`` bytes."""
+    wb = Workbook()
+    ws = wb.active
+    for row in rows:
+        ws.append(row)
+    buf = BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_happy_path_headers_and_row_count() -> None:
+    content = _xlsx_bytes(
+        [
+            ["region", "units", "revenue"],
+            ["north", 10, 1000.5],
+            ["south", 20, 2000.0],
+            ["east", 30, 3000.0],
+            ["west", 40, 4000.0],
+            ["central", 50, 5000.0],
+        ]
+    )
+
+    result = parse_spreadsheet(content, "xlsx")
+
+    assert result.headers == ["region", "units", "revenue"]
+    assert result.total_rows == 5
+    assert result.rows[0] == ["north", 10, 1000.5]
+    assert result.parse_errors == []
+
+
+def test_null_cells_preserved_as_none_not_empty_string() -> None:
+    content = _xlsx_bytes(
+        [
+            ["region", "revenue"],
+            ["north", None],
+            [None, 2000.0],
+        ]
+    )
+
+    result = parse_spreadsheet(content, "xlsx")
+
+    # Nulls survive as None — never coerced to "" — and are NOT parse errors.
+    assert result.rows[0] == ["north", None]
+    assert result.rows[1] == [None, 2000.0]
+    assert result.parse_errors == []
+
+
+def test_date_cells_serialise_to_iso_8601() -> None:
+    content = _xlsx_bytes(
+        [
+            ["event", "when"],
+            ["launch", datetime(2026, 6, 26, 9, 30, 0)],
+        ]
+    )
+
+    result = parse_spreadsheet(content, "xlsx")
+
+    assert result.rows[0][0] == "launch"
+    assert result.rows[0][1] == "2026-06-26T09:30:00"
+
+
+def test_formula_without_cached_result_is_recorded_not_dropped() -> None:
+    content = _xlsx_bytes(
+        [
+            ["a", "b", "total"],
+            [1, 2, "=A2+B2"],
+        ]
+    )
+
+    result = parse_spreadsheet(content, "xlsx")
+
+    # openpyxl never computed the formula, so the value is absent: we emit None
+    # for the cell AND surface a structured parse error rather than silently
+    # dropping it.
+    assert result.rows[0][2] is None
+    assert len(result.parse_errors) == 1
+    err = result.parse_errors[0]
+    assert err.issue == "formula_cell"
+    assert err.column == "total"
+    assert "A2+B2" in err.raw_value
+
+
+def test_excel_error_literal_is_recorded_and_nulled() -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.append(["value"])
+    ws["A2"] = "#REF!"  # openpyxl binds known error codes to data_type "e"
+    buf = BytesIO()
+    wb.save(buf)
+
+    result = parse_spreadsheet(buf.getvalue(), "xlsx")
+
+    assert result.rows[0][0] is None
+    assert len(result.parse_errors) == 1
+    assert result.parse_errors[0].issue == "error_cell"
+    assert result.parse_errors[0].raw_value == "#REF!"
+
+
+def test_blank_header_cell_becomes_column_n() -> None:
+    content = _xlsx_bytes(
+        [
+            ["region", None, "revenue"],
+            ["north", "x", 1000],
+        ]
+    )
+
+    result = parse_spreadsheet(content, "xlsx")
+
+    assert result.headers == ["region", "Column 2", "revenue"]
+
+
+def test_header_only_sheet_yields_zero_rows() -> None:
+    content = _xlsx_bytes([["region", "revenue"]])
+
+    result = parse_spreadsheet(content, "xlsx")
+
+    assert result.headers == ["region", "revenue"]
+    assert result.total_rows == 0
+    assert result.rows == []
+
+
+def test_empty_workbook_raises() -> None:
+    wb = Workbook()
+    buf = BytesIO()
+    wb.save(buf)
+
+    with pytest.raises(SpreadsheetParseError):
+        parse_spreadsheet(buf.getvalue(), "xlsx")
+
+
+def test_unreadable_content_raises() -> None:
+    with pytest.raises(SpreadsheetParseError):
+        parse_spreadsheet(b"this is not a spreadsheet", "xlsx")
+
+
+def test_route_happy_path(client: TestClient) -> None:
+    content = _xlsx_bytes([["region", "revenue"], ["north", 1000]])
+
+    response = client.post(
+        "/api/parse-file",
+        files={"file": ("data.xlsx", content, "application/vnd.openxmlformats")},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["headers"] == ["region", "revenue"]
+    assert body["total_rows"] == 1
+    assert body["parse_errors"] == []
+
+
+def test_route_rejects_legacy_xls(client: TestClient) -> None:
+    response = client.post(
+        "/api/parse-file",
+        files={"file": ("legacy.xls", b"whatever", "application/vnd.ms-excel")},
+    )
+
+    assert response.status_code == 400
+    assert ".xls" in response.json()["detail"]
+
+
+def test_route_rejects_unsupported_extension(client: TestClient) -> None:
+    response = client.post(
+        "/api/parse-file",
+        files={"file": ("deck.pptx", b"whatever", "application/octet-stream")},
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported file type" in response.json()["detail"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.3",
-        "xlsx": "^0.18.5",
         "xml2js": "^0.6.2",
         "zod": "^3.23.8"
       },
@@ -3646,15 +3645,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -3906,19 +3896,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4009,15 +3986,6 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4051,18 +4019,6 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4718,15 +4674,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fraction.js": {
@@ -6170,18 +6117,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -7167,24 +7102,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7281,27 +7198,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "xlsx": "^0.18.5",
     "xml2js": "^0.6.2",
     "zod": "^3.23.8"
   },

--- a/src/components/dashboard/DataPreview.tsx
+++ b/src/components/dashboard/DataPreview.tsx
@@ -43,7 +43,7 @@ const DataPreview: React.FC<DataPreviewProps> = ({ data, fileName }) => {
                 <TableRow key={rowIndex}>
                   {row.map((cell, cellIndex) => (
                     <TableCell key={cellIndex} className="max-w-xs truncate">
-                      {String(cell)}
+                      {cell === null || cell === undefined ? '' : String(cell)}
                     </TableCell>
                   ))}
                 </TableRow>

--- a/src/utils/fileParser.ts
+++ b/src/utils/fileParser.ts
@@ -1,17 +1,30 @@
 
 import Papa from 'papaparse';
-import * as XLSX from 'xlsx';
 import * as xml2js from 'xml2js';
 import * as pdfjsLib from 'pdfjs-dist';
 
 // Set up PDF.js worker
 pdfjsLib.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjsLib.version}/pdf.worker.min.js`;
 
+// A cell the backend parser could not represent faithfully (an Excel error
+// literal, or a formula with no cached result). Surfaced rather than dropped,
+// mirroring the backend CellParseError contract — see
+// backend/models/parsed_file.py.
+export interface ParseError {
+  row: number;
+  column: string;
+  issue: 'formula_cell' | 'error_cell';
+  rawValue: string;
+}
+
 export interface ParsedData {
   headers: string[];
   rows: any[][];
   totalRows: number;
   fileType: string;
+  // Present only for spreadsheet uploads parsed server-side; undefined for the
+  // client-side formats below. Optional so existing consumers stay valid.
+  parseErrors?: ParseError[];
 }
 
 export interface ParseResult {
@@ -67,8 +80,10 @@ const parseCSV = (file: File): Promise<ParseResult> => {
         }
 
         const headers = results.meta.fields || [];
-        const rows = results.data.map((row: any) => 
-          headers.map(header => row[header] || '')
+        // Preserve empty cells as null (detect-don't-fix) rather than coercing
+        // to '' — the parse layer must not silently rewrite missing values.
+        const rows = results.data.map((row: any) =>
+          headers.map(header => row[header] ?? null)
         );
 
         resolve({
@@ -197,52 +212,65 @@ const parseJSON = (file: File): Promise<ParseResult> => {
   });
 };
 
-const parseExcel = (file: File): Promise<ParseResult> => {
-  return new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
+// Shape returned by POST /api/parse-file (snake_case JSON from the FastAPI
+// backend). Mapped to ParsedData below.
+interface ParsedFileResponse {
+  headers: string[];
+  rows: any[][];
+  total_rows: number;
+  file_type: string;
+  parse_errors: { row: number; column: string; issue: 'formula_cell' | 'error_cell'; raw_value: string }[];
+}
+
+// Spreadsheet parsing moved server-side: the browser-side `xlsx` (SheetJS)
+// package was removed to clear two HIGH advisories (GHSA-4r6h-8v6p-xvw6,
+// GHSA-5pgg-2g8v-p4x9). The raw file is POSTed to the backend, which parses it
+// with openpyxl (null-preserving, no pandas coercion) and returns ParsedData.
+const parseExcel = async (file: File): Promise<ParseResult> => {
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch('/api/parse-file', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      // FastAPI returns { detail: "..." } on 4xx; fall back to status text.
+      let detail = response.statusText;
       try {
-        const data = new Uint8Array(e.target?.result as ArrayBuffer);
-        const workbook = XLSX.read(data, { type: 'array' });
-        
-        const firstSheetName = workbook.SheetNames[0];
-        const worksheet = workbook.Sheets[firstSheetName];
-        
-        const jsonData = XLSX.utils.sheet_to_json(worksheet, { header: 1 });
-        
-        if (jsonData.length === 0) {
-          resolve({
-            success: false,
-            error: 'Excel file appears to be empty'
-          });
-          return;
-        }
-
-        const headers = (jsonData[0] as any[]).map((header, index) => 
-          header ? String(header) : `Column ${index + 1}`
-        );
-        const rows = jsonData.slice(1).map((row: any) => 
-          headers.map((_, index) => row[index] || '')
-        );
-
-        resolve({
-          success: true,
-          data: {
-            headers,
-            rows,
-            totalRows: rows.length,
-            fileType: file.name.split('.').pop()?.toLowerCase() || 'excel'
-          }
-        });
-      } catch (error) {
-        resolve({
-          success: false,
-          error: `Excel parsing error: ${error instanceof Error ? error.message : 'Unknown error'}`
-        });
+        const body = await response.json();
+        if (body?.detail) detail = body.detail;
+      } catch {
+        // non-JSON error body; keep statusText
       }
+      return { success: false, error: `Excel parsing error: ${detail}` };
+    }
+
+    const payload = (await response.json()) as ParsedFileResponse;
+
+    return {
+      success: true,
+      data: {
+        headers: payload.headers,
+        rows: payload.rows,
+        totalRows: payload.total_rows,
+        fileType: payload.file_type,
+        parseErrors: payload.parse_errors.map((e) => ({
+          row: e.row,
+          column: e.column,
+          issue: e.issue,
+          rawValue: e.raw_value,
+        })),
+      },
     };
-    reader.readAsArrayBuffer(file);
-  });
+  } catch (error) {
+    return {
+      success: false,
+      error: `Excel parsing error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+    };
+  }
 };
 
 const parseXML = (file: File): Promise<ParseResult> => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,15 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    // Proxy API calls to the FastAPI backend so the browser talks to it
+    // same-origin (no CORS needed in dev). The server-side spreadsheet parser
+    // (POST /api/parse-file) lives there — see backend/api/app.py.
+    proxy: {
+      "/api": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary

Resolves the final HIGH advisory from the Story 1.4 security sweep (Issue #24). Removes the `xlsx` (SheetJS `^0.18.5`) frontend dependency — frozen on npm with two unpatched HIGH CVEs and no fix path:

- **Prototype Pollution** — GHSA-4r6h-8v6p-xvw6
- **ReDoS** — GHSA-5pgg-2g8v-p4x9

Both HIGH advisories are **eliminated** from `npm audit`.

## Architecture decision — Path B (server-side parse)

ExcelJS was the original candidate, but it's a Node.js library and our backend is FastAPI/Python. The correct equivalent is **openpyxl** — already an indirect dependency (via pandas) and on the Python/pip audit graph, which preserves the same Dependabot-visibility posture that motivated leaving SheetJS. The browser now POSTs the raw file to a new endpoint instead of parsing in-page, which also eliminates the ExcelJS browser-bundling risk entirely.

Crucially, the endpoint drives **openpyxl directly, not `pandas.read_excel`** — the latter silently coerces dtypes and fills NaN before the data is ever inspected, which is contrary to the platform's detect-don't-fix constraint.

## What changed

**Backend (new)**
- `backend/models/parsed_file.py` — `ParsedFileResponse` / `CellParseError` Pydantic contract mirroring the frontend `ParsedData` shape.
- `backend/api/parse_file.py` — `POST /api/parse-file`. Owns the cell-iteration loop: null cells preserved as `null`, dates → ISO 8601, Excel error literals (`#REF!`…) and missing-result formulas surfaced as structured `parse_errors` rather than dropped. Two-pass read (`data_only` False/True) to retain formula awareness.
- `backend/api/app.py` — minimal FastAPI host so the endpoint is runnable today (legacy `main*.py` are off-limits; the full web backend is Epic 3).
- `backend/tests/test_parse_file.py` — 12 tests, all green.

**Frontend**
- `src/utils/fileParser.ts` — `parseExcel()` now `fetch`es `/api/parse-file`; SheetJS import removed. `ParsedData` gains optional `parseErrors[]`. CSV empty cells preserved as `null` (`?? null`) instead of coerced to `''` (detect-don't-fix alignment).
- `src/components/dashboard/DataPreview.tsx` — render `null`/`undefined` cells as blank (display-only) so preserved nulls don't surface as the literal `"null"`.
- `vite.config.ts` — proxy `/api` → `http://localhost:8000` so the browser reaches FastAPI same-origin in dev.

## Validation

| Gate | Result |
|------|--------|
| `npm audit` xlsx HIGH | **0** (both CVEs gone) |
| `npx tsc --noEmit` | clean |
| `npm run build` | green (exit 0) |
| backend tests | **123 pass** (12 new) |
| SheetJS imports / `XLSX.` calls in src | **0** |

## ~~⚠️ Reviewer decision needed — legacy `.xls`~~ Resolved

### Option 1 selected — `.xls` dropped from upload UI

openpyxl reads OOXML (`.xlsx`/`.xlsm`) **only**; it cannot parse legacy binary `.xls` (BIFF format, pre-Excel 2007). The options were:

1. ✅ **Drop `.xls` from the advertised formats** ← selected
2. Add a dedicated `.xls` reader server-side (e.g. `xlrd==1.2` or `pyexcel-xls`)
3. Keep advertised + rely on the 400 message

**Rationale for Option 1:** Both `xlrd` (pinned to `1.2` since its author dropped `.xls` support) and `pyexcel-xls` are effectively unmaintained and have their own security-relevant history. Reintroducing an unmaintained dependency to support a near-obsolete format that predates Excel 2007 is not a trade-off worth making. The backend `400` is retained as defense-in-depth (API clients and `curl` can still hit the endpoint directly).

**What changed (follow-up commit `c6d99d5`):**
- `UploadArea.tsx` — `.xls` removed from `accept` attribute, removed from the supported-formats helper text, and a **specific client-side rejection message** added before the file reaches the API: *"Legacy .xls format isn't supported. Please save as .xlsx and re-upload."* This is distinct from the generic unsupported-format error so users know exactly what to do.

**Note:** No frontend test runner (vitest/jest) is configured in this project. The `.xls` rejection path is covered by the client-side guard and the backend 400; a frontend unit test can be added when a test framework is set up (tracked as a follow-up).

## Follow-ups (out of scope here)
- Pre-existing **vite/esbuild** moderate→high advisory (GHSA-67mh-4wv8-2f99) remains; fix is a breaking vite major bump. Unrelated to #24.
- `parseTXT` / `parseJSON` still coerce empty cells to `''`; only CSV was aligned to `null` here (CSV is the primary path). Worth a consistency pass.
- `/api` error responses use FastAPI's default `{detail}`, not RFC 7807 Problem Details — the API-layer standard lands with Epic 3.
- Frontend unit test coverage for `UploadArea` (no test runner currently configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)