### PR TITLE
Implement Story 2.1: Configuration Layer with Pydantic Models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ OPENAI_API_KEY=
 # Google (Gemini) fallback (Phase 1 narrative generator)
 GOOGLE_API_KEY=
 
+# SMTP — Phase 2 alert delivery (credentials NEVER go in config.yaml)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_FROM=
+
 # Supabase — UNIFIED single project starting Phase 3 (do NOT commit real keys)
 SUPABASE_URL=
 SUPABASE_ANON_KEY=

--- a/_bmad-output/implementation-artifacts/2-1-configuration-layer.md
+++ b/_bmad-output/implementation-artifacts/2-1-configuration-layer.md
@@ -1,6 +1,6 @@
 # Story 2.1: Configuration Layer
 
-Status: ready-for-dev
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -60,52 +60,52 @@ so that agents can be configured without code changes and settings can be modifi
 
 ## Tasks / Subtasks
 
-- [ ] **Task 0 — Resolve schema location & read the existing stub** (AC: 1, 3)
-  - [ ] Read `backend/pipeline/config.py` — it currently holds `configure_logging()`,
+- [x] **Task 0 — Resolve schema location & read the existing stub** (AC: 1, 3)
+  - [x] Read `backend/pipeline/config.py` — it currently holds `configure_logging()`,
         `bind_pipeline_run_id()`, and a **stub stdlib `@dataclass PipelineConfig`** (empty). Do NOT
         delete the logging functions — `conftest.py:20` imports `configure_logging` from here and the
         whole suite depends on it.
-  - [ ] Follow the prescribed resolution in Dev Notes: define the Pydantic models in
+  - [x] Follow the prescribed resolution in Dev Notes: define the Pydantic models in
         `backend/models/pipeline_config.py`; replace the stub in `pipeline/config.py` with a
         re-export so `from backend.pipeline.config import PipelineConfig` keeps working.
 
-- [ ] **Task 1 — Define the Pydantic config contract** `backend/models/pipeline_config.py` (AC: 1, 2)
-  - [ ] `ThresholdConfig` (or a `dict[str, float]` field with a validator) — per-metric fractional
+- [x] **Task 1 — Define the Pydantic config contract** `backend/models/pipeline_config.py` (AC: 1, 2)
+  - [x] `ThresholdConfig` (or a `dict[str, float]` field with a validator) — per-metric fractional
         thresholds; default `DEFAULT_THRESHOLD = 0.15`; every value must be `> 0` (reject negative/zero).
-  - [ ] `ScheduleConfig` — accepts either an interval enum (`daily`/`weekly`/`monthly`) or a cron
+  - [x] `ScheduleConfig` — accepts either an interval enum (`daily`/`weekly`/`monthly`) or a cron
         string; validate cron via `croniter` (raise on malformed). Exactly one of interval/cron.
-  - [ ] `DataSourceConfig` — list of file paths or directories (non-empty list of `str`/`Path`).
-  - [ ] `OutputConfig` — `format` (`docx`/`pdf`, default `docx`), `output_dir` (default `output/`).
-  - [ ] `AlertConfig` — `recipients: list[EmailStr]` (validate email format via Pydantic `EmailStr`).
-  - [ ] Root `PipelineConfig(BaseModel)` composing the above, plus a `@classmethod load(cls, path: str
+  - [x] `DataSourceConfig` — list of file paths or directories (non-empty list of `str`/`Path`).
+  - [x] `OutputConfig` — `format` (`docx`/`pdf`, default `docx`), `output_dir` (default `output/`).
+  - [x] `AlertConfig` — `recipients: list[EmailStr]` (validate email format via Pydantic `EmailStr`).
+  - [x] Root `PipelineConfig(BaseModel)` composing the above, plus a `@classmethod load(cls, path: str
         | Path | None = None) -> "PipelineConfig"` that reads YAML, merges env-sourced secrets, and
         validates. Use `model_config = ConfigDict(...)` per Pydantic v2.
 
-- [ ] **Task 2 — Implement the loader** `PipelineConfig.load()` (AC: 2, 3, 4, 5, 6)
-  - [ ] Default path = `config.yaml` at project root; accept an explicit path for tests.
-  - [ ] Parse with `yaml.safe_load` (PyYAML). JSON is a valid subset — `safe_load` reads `.json` too;
+- [x] **Task 2 — Implement the loader** `PipelineConfig.load()` (AC: 2, 3, 4, 5, 6)
+  - [x] Default path = `config.yaml` at project root; accept an explicit path for tests.
+  - [x] Parse with `yaml.safe_load` (PyYAML). JSON is a valid subset — `safe_load` reads `.json` too;
         no separate JSON branch needed (note this in a comment).
-  - [ ] Call `load_dotenv()` (python-dotenv) then read `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`,
+  - [x] Call `load_dotenv()` (python-dotenv) then read `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`,
         `SMTP_PASSWORD`, `SMTP_FROM` from `os.environ`. Surface them on the typed config (e.g., an
         `SmtpSettings` sub-object) — but they originate ONLY from env, never from the YAML.
-  - [ ] Wrap `pydantic.ValidationError`, `yaml.YAMLError`, and `FileNotFoundError` in
+  - [x] Wrap `pydantic.ValidationError`, `yaml.YAMLError`, and `FileNotFoundError` in
         `ConfigurationError` with a descriptive message (AC2). Re-read on every call (AC5 — no caching).
-  - [ ] Emit `structlog.get_logger().info("config_loaded", schedule=..., threshold_keys=...,
+  - [x] Emit `structlog.get_logger().info("config_loaded", schedule=..., threshold_keys=...,
         recipient_count=..., output_format=...)` — **assert no secret values are in the log payload.**
 
-- [ ] **Task 3 — Replace the stub & wire exports** `backend/pipeline/config.py` (AC: 3)
-  - [ ] Remove the empty `@dataclass PipelineConfig`; add `from backend.models.pipeline_config import
+- [x] **Task 3 — Replace the stub & wire exports** `backend/pipeline/config.py` (AC: 3)
+  - [x] Remove the empty `@dataclass PipelineConfig`; add `from backend.models.pipeline_config import
         PipelineConfig` (re-export) so both import paths resolve to the one Pydantic model.
-  - [ ] Update the module docstring: the "full config surface lands in Story 1.6" note is stale —
+  - [x] Update the module docstring: the "full config surface lands in Story 1.6" note is stale —
         replace with "config schema defined in Story 2.1; see `backend/models/pipeline_config.py`".
-  - [ ] Keep `configure_logging()` and `bind_pipeline_run_id()` exactly as-is.
+  - [x] Keep `configure_logging()` and `bind_pipeline_run_id()` exactly as-is.
 
-- [ ] **Task 4 — Author `config.yaml` + update `.env.example` + `pyproject.toml`** (AC: 1, 4)
-  - [ ] Create `config.yaml` at repo root with a documented, working example (see Dev Notes for the
+- [x] **Task 4 — Author `config.yaml` + update `.env.example` + `pyproject.toml`** (AC: 1, 4)
+  - [x] Create `config.yaml` at repo root with a documented, working example (see Dev Notes for the
         canonical shape). Comment each section. NO secrets in it.
-  - [ ] Add to `.env.example`: `SMTP_HOST=`, `SMTP_PORT=587`, `SMTP_USERNAME=`, `SMTP_PASSWORD=`,
+  - [x] Add to `.env.example`: `SMTP_HOST=`, `SMTP_PORT=587`, `SMTP_USERNAME=`, `SMTP_PASSWORD=`,
         `SMTP_FROM=` under a `# SMTP — Phase 2 alert delivery` header.
-  - [ ] Add deps to **both** `pyproject.toml` `dependencies` **and** `backend/requirements.txt`:
+  - [x] Add deps to **both** `pyproject.toml` `dependencies` **and** `backend/requirements.txt`:
         `pyyaml>=6.0`, `croniter>=2.0`, `email-validator>=2.0` (required by Pydantic `EmailStr`), and
         reconcile `python-dotenv>=1.0` (already in `requirements.txt`, **missing from `pyproject.toml`** —
         add it there). The two files are hand-maintained and already drift (`docxtpl`/`weasyprint`/
@@ -114,16 +114,16 @@ so that agents can be configured without code changes and settings can be modifi
         the four config deps land in both. Verify with:
         `grep -iE 'pyyaml|croniter|email-validator|python-dotenv' pyproject.toml backend/requirements.txt`
 
-- [ ] **Task 5 — Tests** `backend/tests/test_config.py` (AC: 2, 3, 4, 5, 6)
-  - [ ] Valid config → typed `PipelineConfig`, defaults applied (threshold `0.15`, format `docx`).
-  - [ ] Missing required field → `ConfigurationError` (not bare `ValidationError`).
-  - [ ] Invalid values: malformed cron, negative threshold, bad email → each raises `ConfigurationError`.
-  - [ ] Env override: set `SMTP_PASSWORD` via `monkeypatch.setenv`, assert it lands on the config and
+- [x] **Task 5 — Tests** `backend/tests/test_config.py` (AC: 2, 3, 4, 5, 6)
+  - [x] Valid config → typed `PipelineConfig`, defaults applied (threshold `0.15`, format `docx`).
+  - [x] Missing required field → `ConfigurationError` (not bare `ValidationError`).
+  - [x] Invalid values: malformed cron, negative threshold, bad email → each raises `ConfigurationError`.
+  - [x] Env override: set `SMTP_PASSWORD` via `monkeypatch.setenv`, assert it lands on the config and
         is absent from any YAML on disk.
-  - [ ] Reload: write `config.yaml` to `tmp_path`, `load()`, mutate the file, `load()` again, assert
+  - [x] Reload: write `config.yaml` to `tmp_path`, `load()`, mutate the file, `load()` again, assert
         the second instance reflects the change.
-  - [ ] Use `tmp_path` for all file I/O — never write to the real repo-root `config.yaml`.
-  - [ ] Capture logs (e.g., `structlog` testing capture or `caplog`) and assert `config_loaded` fires
+  - [x] Use `tmp_path` for all file I/O — never write to the real repo-root `config.yaml`.
+  - [x] Capture logs (e.g., `structlog` testing capture or `caplog`) and assert `config_loaded` fires
         and the payload contains no secret values.
 
 ## Dev Notes
@@ -297,8 +297,49 @@ output:
 
 ### Agent Model Used
 
+Claude Code (remote scheduled routine, 2026-07-04)
+
 ### Debug Log References
+
+- Baseline before implementation: `pytest backend/tests/` — 123 passed, 1 skipped
+  (pre-existing skip: anthropic SDK not installed in test env).
+- After implementation: 150 passed, 1 skipped — 27 new tests in
+  `backend/tests/test_config.py`, zero regressions.
+- Test invocation (pytest/pandera/fastapi are not in the uv lock):
+  `uv run --with 'pytest>=8.2' --with 'pandera==0.30.1' --with fastapi --with httpx
+  --with python-multipart --with openpyxl --with pdfplumber pytest backend/tests/`
 
 ### Completion Notes List
 
+- Followed the prescribed schema-location resolution exactly: Pydantic models live in
+  `backend/models/pipeline_config.py`; `backend/pipeline/config.py` re-exports
+  `PipelineConfig` and keeps `configure_logging()` / `bind_pipeline_run_id()` untouched.
+- `PipelineConfig.load()` is stateless (re-reads + re-validates per call — FR10),
+  wraps `ValidationError`/`YAMLError`/`FileNotFoundError` in `ConfigurationError`,
+  and uses `errors(include_input=False)` so env-sourced secret values can never leak
+  into exception messages.
+- SMTP settings surface on `config.smtp` (`SmtpSettings`) sourced ONLY from env; a
+  top-level `smtp`/`secrets`/`credentials`/`api_keys` key in config.yaml is rejected
+  with a descriptive ConfigurationError (defense-in-depth beyond `extra="forbid"`).
+- `metric_thresholds` is `dict[str, float]` with a >0 validator plus
+  `threshold_for(metric)` falling back to `DEFAULT_THRESHOLD = 0.15`, generic enough
+  for 2.2 drift per-column reads and 2.4 alert rules.
+- Root model uses `extra="forbid"` so typo'd keys fail loudly with the offending
+  field named (AC2).
+- Dependency drift between pyproject.toml and backend/requirements.txt left as-is per
+  Task 4; the four config deps (pyyaml, croniter, email-validator, python-dotenv)
+  landed in both, uv.lock regenerated via `uv sync`.
+- Security review (DoD gate): no findings. Verified safe_load-only YAML parsing, no
+  secrets in config.yaml/logs/error messages, lockfile gained only the four declared
+  packages plus expected transitives (dnspython, idna).
+
 ### File List
+
+- backend/models/pipeline_config.py (new)
+- backend/tests/test_config.py (new)
+- config.yaml (new)
+- backend/pipeline/config.py (modified — stub → re-export, docstring updated)
+- .env.example (modified — SMTP_* placeholders)
+- pyproject.toml (modified — +pyyaml, croniter, email-validator, python-dotenv)
+- backend/requirements.txt (modified — +pyyaml, croniter, email-validator)
+- uv.lock (regenerated)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -84,7 +84,7 @@ development_status:
 
   # Epic 2: Automated Reporting & Data Monitoring
   epic-2: in-progress
-  2-1-configuration-layer: done  # commit 28a4a39 (claude/intelligent-lamport-5pkjd5) 2026-07-04; 27 new tests, 150 total green; security review: no findings
+  2-1-configuration-layer: done  # PR #29, commit 28a4a39 (claude/intelligent-lamport-5pkjd5) 2026-07-04; 27 new tests, 150 total green; security review: no findings
   2-2-llm-client-abstraction: ready-for-dev  # inserted 2026-07-02: prerequisite for 2.3 and 2.4 LLM calls
   2-2-drift-engine: backlog
   2-3-reporting-agent: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -42,7 +42,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-14
-last_updated: 2026-07-02  # updated: story 2-2-llm-client-abstraction created (ready-for-dev); inserted between 2.1 and original 2.2
+last_updated: 2026-07-04  # updated: 2-1-configuration-layer done (commit 28a4a39, 150 tests green, security review clean)
 project: SavvyCortex
 project_key: NOKEY
 tracking_system: file-system
@@ -84,7 +84,7 @@ development_status:
 
   # Epic 2: Automated Reporting & Data Monitoring
   epic-2: in-progress
-  2-1-configuration-layer: ready-for-dev
+  2-1-configuration-layer: done  # commit 28a4a39 (claude/intelligent-lamport-5pkjd5) 2026-07-04; 27 new tests, 150 total green; security review: no findings
   2-2-llm-client-abstraction: ready-for-dev  # inserted 2026-07-02: prerequisite for 2.3 and 2.4 LLM calls
   2-2-drift-engine: backlog
   2-3-reporting-agent: backlog

--- a/backend/models/pipeline_config.py
+++ b/backend/models/pipeline_config.py
@@ -1,0 +1,216 @@
+"""Pipeline configuration Pydantic models (Story 2.1).
+
+Defines the typed contract for the user-facing ``config.yaml`` at project
+root: data sources, report schedule, per-metric thresholds, alert
+recipients, and output settings. Loaded via :meth:`PipelineConfig.load`,
+which re-reads and re-validates the file on every call so scheduled agents
+pick up on-disk changes without a process restart (FR10).
+
+Secrets discipline (NFR3): SMTP credentials are sourced exclusively from
+environment variables (``.env`` in dev via python-dotenv) and are never
+read from — or permitted in — ``config.yaml``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Literal
+
+import structlog
+import yaml
+from croniter import croniter
+from dotenv import load_dotenv
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from backend.errors.exceptions import ConfigurationError
+
+# Applied when a metric has no explicit entry in ``metric_thresholds``.
+# 0.15 == ±15% week-over-week, the FR7 default.
+DEFAULT_THRESHOLD: float = 0.15
+
+# Repo root: backend/models/pipeline_config.py -> backend/models -> backend -> root.
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_CONFIG_PATH = _PROJECT_ROOT / "config.yaml"
+
+# Top-level YAML keys that would smuggle secrets into version control.
+_FORBIDDEN_YAML_KEYS = frozenset({"smtp", "secrets", "credentials", "api_keys"})
+
+
+class ScheduleConfig(BaseModel):
+    """Report schedule: a named interval OR a cron expression, never both."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    interval: Literal["daily", "weekly", "monthly"] | None = None
+    cron: str | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_of_interval_or_cron(self) -> ScheduleConfig:
+        if (self.interval is None) == (self.cron is None):
+            raise ValueError(
+                "report_schedule requires exactly one of 'interval' "
+                "(daily|weekly|monthly) or 'cron'"
+            )
+        if self.cron is not None and not croniter.is_valid(self.cron):
+            raise ValueError(f"invalid cron expression: {self.cron!r}")
+        return self
+
+    def describe(self) -> str:
+        """Human-readable schedule summary for logging."""
+        return self.interval if self.interval is not None else f"cron:{self.cron}"
+
+
+class OutputConfig(BaseModel):
+    """Report output settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    format: Literal["docx", "pdf"] = "docx"
+    output_dir: Path = Path("output")
+
+
+class SmtpSettings(BaseModel):
+    """SMTP delivery settings — sourced ONLY from environment variables.
+
+    All fields are optional at load time: alert delivery arrives in
+    Story 2.4, and the Monitoring Agent is responsible for rejecting a
+    send attempt when credentials are absent.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    host: str | None = None
+    port: int = 587
+    username: str | None = None
+    password: str | None = None
+    from_address: str | None = None
+
+    @classmethod
+    def env_values(cls) -> dict[str, Any]:
+        """Raw SMTP values from the environment (unvalidated)."""
+        values: dict[str, Any] = {
+            "host": os.environ.get("SMTP_HOST") or None,
+            "username": os.environ.get("SMTP_USERNAME") or None,
+            "password": os.environ.get("SMTP_PASSWORD") or None,
+            "from_address": os.environ.get("SMTP_FROM") or None,
+        }
+        port = os.environ.get("SMTP_PORT")
+        if port:
+            values["port"] = port
+        return values
+
+
+class PipelineConfig(BaseModel):
+    """Root configuration contract for the Phase 2 agents.
+
+    Consumed by the Drift Engine (thresholds), the Reporting Agent
+    (``data_sources``, ``report_schedule``, ``output``) and the Monitoring
+    Agent (``metric_thresholds``, ``alert_recipients``, ``smtp``).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    data_sources: list[Path] = Field(min_length=1)
+    report_schedule: ScheduleConfig
+    metric_thresholds: dict[str, float] = Field(default_factory=dict)
+    alert_recipients: list[EmailStr]
+    output: OutputConfig = Field(default_factory=OutputConfig)
+    smtp: SmtpSettings = Field(default_factory=SmtpSettings)
+
+    @field_validator("metric_thresholds")
+    @classmethod
+    def _thresholds_positive(cls, value: dict[str, float]) -> dict[str, float]:
+        for metric, threshold in value.items():
+            if threshold <= 0:
+                raise ValueError(
+                    f"metric_thresholds[{metric!r}] must be > 0, got {threshold}"
+                )
+        return value
+
+    def threshold_for(self, metric: str) -> float:
+        """Fractional change threshold for ``metric`` (default ±15%)."""
+        return self.metric_thresholds.get(metric, DEFAULT_THRESHOLD)
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> PipelineConfig:
+        """Read, validate, and return the config from ``path``.
+
+        Stateless by design: re-reads and re-validates the file on every
+        call so a scheduled agent's next run reflects on-disk edits (FR10).
+        Defaults to ``config.yaml`` at project root. Raises
+        :class:`ConfigurationError` on any missing, unparseable, or
+        invalid configuration — pydantic ``ValidationError`` never escapes.
+        """
+        config_path = Path(path) if path is not None else _DEFAULT_CONFIG_PATH
+        load_dotenv()
+
+        try:
+            raw_text = config_path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise ConfigurationError(f"config file not found: {config_path}") from exc
+        except OSError as exc:
+            raise ConfigurationError(f"config file unreadable: {config_path}: {exc}") from exc
+
+        # JSON is a strict subset of YAML, so safe_load parses .json config
+        # too — no separate JSON branch needed. NEVER yaml.load (NFR4).
+        try:
+            raw = yaml.safe_load(raw_text)
+        except yaml.YAMLError as exc:
+            raise ConfigurationError(
+                f"config file is not valid YAML: {config_path}: {exc}"
+            ) from exc
+
+        if not isinstance(raw, dict):
+            raise ConfigurationError(
+                f"config file must contain a mapping of settings, "
+                f"got {type(raw).__name__}: {config_path}"
+            )
+
+        forbidden = _FORBIDDEN_YAML_KEYS.intersection(raw)
+        if forbidden:
+            raise ConfigurationError(
+                f"secret sections {sorted(forbidden)} are not allowed in "
+                f"{config_path.name} — SMTP credentials and API keys belong "
+                f"in environment variables (.env)"
+            )
+
+        raw["smtp"] = SmtpSettings.env_values()
+
+        try:
+            config = cls.model_validate(raw)
+        except ValidationError as exc:
+            raise ConfigurationError(
+                f"invalid configuration in {config_path}: "
+                f"{_format_validation_error(exc)}"
+            ) from exc
+
+        # Summary only — never SMTP credentials, API keys, or recipient
+        # addresses (PII-adjacent: log the count, not the list).
+        structlog.get_logger().info(
+            "config_loaded",
+            config_path=str(config_path),
+            data_source_count=len(config.data_sources),
+            schedule=config.report_schedule.describe(),
+            threshold_keys=sorted(config.metric_thresholds),
+            recipient_count=len(config.alert_recipients),
+            output_format=config.output.format,
+        )
+        return config
+
+
+def _format_validation_error(exc: ValidationError) -> str:
+    """Flatten a pydantic ValidationError into 'field: message' pairs."""
+    parts = []
+    for err in exc.errors(include_url=False, include_input=False):
+        loc = ".".join(str(piece) for piece in err["loc"]) or "<root>"
+        parts.append(f"{loc}: {err['msg']}")
+    return "; ".join(parts)

--- a/backend/pipeline/config.py
+++ b/backend/pipeline/config.py
@@ -1,10 +1,10 @@
 """Pipeline configuration and logging setup.
 
-Story 1.1 installs the logging hook and a stub :class:`PipelineConfig`.
-The full config surface (thresholds, LLM provider selection, rendering
-options, baseline paths) lands in Story 1.6 when the orchestrator needs
-it end-to-end. Do not expand this dataclass ad-hoc — wait for Story 1.6
-so the schema is designed as a coherent whole.
+The config schema is defined in Story 2.1; see
+:mod:`backend.models.pipeline_config` for the Pydantic contract
+(:class:`PipelineConfig` and its sub-models). It is re-exported here so
+``from backend.pipeline.config import PipelineConfig`` keeps working —
+this module retains the logging hooks only.
 
 Logging discipline (enforced here):
 
@@ -23,19 +23,11 @@ Logging discipline (enforced here):
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 import structlog
 
+from backend.models.pipeline_config import PipelineConfig
 
-@dataclass
-class PipelineConfig:
-    """Pipeline configuration stub.
-
-    Full schema is defined in Story 1.6 (orchestrator). Intentionally
-    empty here so downstream modules can import the symbol without a
-    circular dependency on config shape that is not yet designed.
-    """
+__all__ = ["PipelineConfig", "configure_logging", "bind_pipeline_run_id"]
 
 
 def configure_logging() -> None:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,3 +28,8 @@ structlog==25.5.0      # JSON structured logging with correlation IDs
 pytest>=8.2            # Test runner (pyproject pins exact config)
 pytest-cov             # Coverage reporting
 python-dotenv>=1.0     # .env loader for local development
+
+# --- Phase 2 configuration layer (added Story 2.1) ---
+pyyaml>=6.0            # config.yaml parsing (safe_load only)
+croniter>=2.0          # cron expression validation in report_schedule
+email-validator>=2.0   # required by pydantic EmailStr (alert_recipients)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,316 @@
+"""Tests for the Story 2.1 configuration layer.
+
+Covers backend/models/pipeline_config.py and the re-export in
+backend/pipeline/config.py: valid load with defaults, every
+ConfigurationError path (missing fields, bad cron, bad threshold, bad
+email, secrets in YAML, missing/unparseable file), environment-variable
+secret sourcing, stateless reload (FR10), and the secret-free
+``config_loaded`` structlog event.
+
+All file I/O goes through ``tmp_path`` — the real repo-root config.yaml
+is never touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import structlog
+import yaml
+
+from backend.errors.exceptions import ConfigurationError
+from backend.models.pipeline_config import (
+    DEFAULT_THRESHOLD,
+    PipelineConfig,
+    ScheduleConfig,
+    SmtpSettings,
+)
+
+_SMTP_ENV_VARS = ["SMTP_HOST", "SMTP_PORT", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_FROM"]
+
+
+@pytest.fixture(autouse=True)
+def _clean_smtp_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate every test from ambient SMTP_* variables and any real .env."""
+    for var in _SMTP_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _valid_config_dict() -> dict:
+    return {
+        "data_sources": ["data/sales.csv"],
+        "report_schedule": {"interval": "weekly"},
+        "metric_thresholds": {"revenue": 0.15, "units_sold": 0.20},
+        "alert_recipients": ["ops@example.com"],
+        "output": {"format": "docx", "output_dir": "output/"},
+    }
+
+
+def _write_config(tmp_path: Path, config: dict) -> Path:
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
+    return path
+
+
+class TestValidLoad:
+    def test_valid_config_returns_typed_instance(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, _valid_config_dict())
+
+        config = PipelineConfig.load(path)
+
+        assert isinstance(config, PipelineConfig)
+        assert config.data_sources == [Path("data/sales.csv")]
+        assert config.report_schedule.interval == "weekly"
+        assert config.report_schedule.cron is None
+        assert config.metric_thresholds == {"revenue": 0.15, "units_sold": 0.20}
+        assert config.alert_recipients == ["ops@example.com"]
+        assert config.output.format == "docx"
+        assert config.output.output_dir == Path("output")
+
+    def test_defaults_applied_when_sections_omitted(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        del config_dict["metric_thresholds"]
+        del config_dict["output"]
+        path = _write_config(tmp_path, config_dict)
+
+        config = PipelineConfig.load(path)
+
+        assert config.metric_thresholds == {}
+        assert config.output.format == "docx"
+        assert config.output.output_dir == Path("output")
+
+    def test_threshold_for_falls_back_to_default(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, _valid_config_dict())
+
+        config = PipelineConfig.load(path)
+
+        assert config.threshold_for("units_sold") == 0.20
+        assert config.threshold_for("unlisted_metric") == DEFAULT_THRESHOLD == 0.15
+
+    def test_cron_schedule_accepted(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["report_schedule"] = {"cron": "0 6 * * 1"}
+        path = _write_config(tmp_path, config_dict)
+
+        config = PipelineConfig.load(path)
+
+        assert config.report_schedule.cron == "0 6 * * 1"
+        assert config.report_schedule.interval is None
+
+    def test_json_config_parses_as_yaml_subset(self, tmp_path: Path) -> None:
+        import json
+
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(_valid_config_dict()), encoding="utf-8")
+
+        config = PipelineConfig.load(path)
+
+        assert config.report_schedule.interval == "weekly"
+
+    def test_repo_root_config_yaml_is_valid(self) -> None:
+        """The committed example config at repo root must load (AC1)."""
+        repo_root_config = Path(__file__).resolve().parents[2] / "config.yaml"
+
+        config = PipelineConfig.load(repo_root_config)
+
+        assert config.data_sources
+        assert config.alert_recipients
+
+
+class TestInvalidConfig:
+    def test_missing_required_field_raises_configuration_error(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        del config_dict["data_sources"]
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="data_sources"):
+            PipelineConfig.load(path)
+
+    def test_empty_data_sources_rejected(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["data_sources"] = []
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="data_sources"):
+            PipelineConfig.load(path)
+
+    def test_malformed_cron_raises_configuration_error(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["report_schedule"] = {"cron": "not a cron"}
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="cron"):
+            PipelineConfig.load(path)
+
+    def test_interval_and_cron_together_rejected(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["report_schedule"] = {"interval": "daily", "cron": "0 6 * * 1"}
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="report_schedule"):
+            PipelineConfig.load(path)
+
+    def test_unknown_interval_rejected(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["report_schedule"] = {"interval": "hourly"}
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="interval"):
+            PipelineConfig.load(path)
+
+    @pytest.mark.parametrize("bad_threshold", [-0.15, 0, 0.0])
+    def test_nonpositive_threshold_rejected(self, tmp_path: Path, bad_threshold: float) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["metric_thresholds"] = {"revenue": bad_threshold}
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="metric_thresholds"):
+            PipelineConfig.load(path)
+
+    def test_malformed_email_rejected(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["alert_recipients"] = ["not-an-email"]
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="alert_recipients"):
+            PipelineConfig.load(path)
+
+    def test_unknown_top_level_key_rejected(self, tmp_path: Path) -> None:
+        config_dict = _valid_config_dict()
+        config_dict["metric_treshold"] = {"revenue": 0.15}  # typo'd key
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="metric_treshold"):
+            PipelineConfig.load(path)
+
+    def test_smtp_section_in_yaml_rejected(self, tmp_path: Path) -> None:
+        """Secrets must never live in config.yaml (NFR3)."""
+        config_dict = _valid_config_dict()
+        config_dict["smtp"] = {"password": "hunter2"}
+        path = _write_config(tmp_path, config_dict)
+
+        with pytest.raises(ConfigurationError, match="environment variables"):
+            PipelineConfig.load(path)
+
+    def test_missing_file_raises_configuration_error(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            PipelineConfig.load(tmp_path / "nope.yaml")
+
+    def test_unparseable_yaml_raises_configuration_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.yaml"
+        path.write_text("data_sources: [unclosed", encoding="utf-8")
+
+        with pytest.raises(ConfigurationError, match="not valid YAML"):
+            PipelineConfig.load(path)
+
+    def test_non_mapping_yaml_raises_configuration_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "config.yaml"
+        path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+
+        with pytest.raises(ConfigurationError, match="mapping"):
+            PipelineConfig.load(path)
+
+    def test_validation_error_never_escapes(self, tmp_path: Path) -> None:
+        from pydantic import ValidationError
+
+        path = _write_config(tmp_path, {"data_sources": ["x.csv"]})
+
+        try:
+            PipelineConfig.load(path)
+        except ConfigurationError:
+            pass
+        except ValidationError:  # pragma: no cover - the failure being asserted
+            pytest.fail("pydantic ValidationError escaped PipelineConfig.load()")
+        else:  # pragma: no cover
+            pytest.fail("invalid config did not raise")
+
+
+class TestEnvSecrets:
+    def test_smtp_secrets_sourced_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = _write_config(tmp_path, _valid_config_dict())
+        monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("SMTP_PORT", "2525")
+        monkeypatch.setenv("SMTP_USERNAME", "mailer")
+        monkeypatch.setenv("SMTP_PASSWORD", "s3cret-value")
+        monkeypatch.setenv("SMTP_FROM", "alerts@example.com")
+
+        config = PipelineConfig.load(path)
+
+        assert config.smtp.host == "smtp.example.com"
+        assert config.smtp.port == 2525
+        assert config.smtp.username == "mailer"
+        assert config.smtp.password == "s3cret-value"
+        assert config.smtp.from_address == "alerts@example.com"
+        # The secret exists only in env — never in the YAML on disk.
+        assert "s3cret-value" not in path.read_text(encoding="utf-8")
+
+    def test_smtp_defaults_when_env_absent(self, tmp_path: Path) -> None:
+        path = _write_config(tmp_path, _valid_config_dict())
+
+        config = PipelineConfig.load(path)
+
+        assert config.smtp == SmtpSettings()
+        assert config.smtp.port == 587
+        assert config.smtp.password is None
+
+
+class TestReload:
+    def test_reload_reflects_on_disk_changes(self, tmp_path: Path) -> None:
+        """FR10: load() is stateless — edits apply on the next call."""
+        config_dict = _valid_config_dict()
+        path = _write_config(tmp_path, config_dict)
+        first = PipelineConfig.load(path)
+        assert first.threshold_for("revenue") == 0.15
+
+        config_dict["metric_thresholds"]["revenue"] = 0.25
+        config_dict["report_schedule"] = {"interval": "daily"}
+        config_dict["alert_recipients"].append("oncall@example.com")
+        _write_config(tmp_path, config_dict)
+        second = PipelineConfig.load(path)
+
+        assert second.threshold_for("revenue") == 0.25
+        assert second.report_schedule.interval == "daily"
+        assert len(second.alert_recipients) == 2
+        # The previously returned instance is untouched (no shared cache).
+        assert first.threshold_for("revenue") == 0.15
+
+
+class TestObservability:
+    def test_config_loaded_event_emitted_without_secrets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = _write_config(tmp_path, _valid_config_dict())
+        monkeypatch.setenv("SMTP_PASSWORD", "s3cret-value")
+        monkeypatch.setenv("SMTP_USERNAME", "mailer-user")
+
+        with structlog.testing.capture_logs() as logs:
+            PipelineConfig.load(path)
+
+        events = [entry for entry in logs if entry["event"] == "config_loaded"]
+        assert len(events) == 1
+        event = events[0]
+        assert event["schedule"] == "weekly"
+        assert event["threshold_keys"] == ["revenue", "units_sold"]
+        assert event["recipient_count"] == 1
+        assert event["output_format"] == "docx"
+        assert event["data_source_count"] == 1
+        # No secret values and no recipient addresses anywhere in the payload.
+        payload = repr(event)
+        assert "s3cret-value" not in payload
+        assert "mailer-user" not in payload
+        assert "ops@example.com" not in payload
+
+
+class TestReExport:
+    def test_pipeline_config_reexported_from_pipeline_package(self) -> None:
+        """Both import paths must resolve to the one Pydantic model."""
+        from backend.pipeline.config import PipelineConfig as ReExported
+
+        assert ReExported is PipelineConfig
+
+    def test_schedule_config_describe(self) -> None:
+        assert ScheduleConfig(interval="daily").describe() == "daily"
+        assert ScheduleConfig(cron="0 6 * * 1").describe() == "cron:0 6 * * 1"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,28 @@
+# SavvyCortex pipeline configuration (Phase 2). Secrets live in .env, NOT here.
+# Loaded and validated by backend/models/pipeline_config.py (PipelineConfig.load()).
+# The file is re-read on every load, so edits take effect on the next
+# scheduled agent run without a process restart.
+
+# File path(s) or directory(ies) the agents pull data from.
+data_sources:
+  - data/sales.csv
+
+# Exactly one of `interval` (daily | weekly | monthly) or `cron`.
+report_schedule:
+  interval: weekly
+  # cron: "0 6 * * 1"        # OR a cron expression (mutually exclusive with interval)
+
+# Per-metric fractional change thresholds; 0.15 == ±15%.
+# Metrics not listed here fall back to the 0.15 default.
+metric_thresholds:
+  revenue: 0.15
+  units_sold: 0.20
+
+# Alert delivery targets (email). SMTP credentials come from .env (SMTP_*).
+alert_recipients:
+  - ops@example.com
+
+# Report output settings.
+output:
+  format: docx               # docx | pdf
+  output_dir: output/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
     "pydantic>=2.0",
     "typer>=0.12.1",
     "pandas>=2.0",
+    "pyyaml>=6.0",
+    "croniter>=2.0",
+    "email-validator>=2.0",
+    "python-dotenv>=1.0",
 ]
 
 [tool.pytest.ini_options]

--- a/story.yaml
+++ b/story.yaml
@@ -54,8 +54,9 @@ epic_2:
   stories:
     2-1-configuration-layer:
       status: done
+      pr: 29
       commit: "28a4a39"
-      notes: "Implemented 2026-07-04 on claude/intelligent-lamport-5pkjd5. 27 new tests (150 total green), security review clean."
+      notes: "Implemented 2026-07-04 on claude/intelligent-lamport-5pkjd5 (PR #29). 27 new tests (150 total green), security review clean."
     2-2-llm-client-abstraction:
       status: ready-for-dev
       notes: "Inserted 2026-07-02 before drift engine — prerequisite for 2.3/2.4 LLM calls. Synced from sprint-status.yaml 2026-07-04."

--- a/story.yaml
+++ b/story.yaml
@@ -1,7 +1,7 @@
 # Story Tracker — SavvyCortex
 # Synced from: _bmad-output/implementation-artifacts/sprint-status.yaml
 # Used by: Daily Ops Agent for sprint check and codex sync
-last_synced: "2026-07-01"
+last_synced: "2026-07-04"
 
 epic_1:
   name: "Data Quality & Insight Reports (CLI)"
@@ -53,8 +53,12 @@ epic_2:
   status: in-progress
   stories:
     2-1-configuration-layer:
+      status: done
+      commit: "28a4a39"
+      notes: "Implemented 2026-07-04 on claude/intelligent-lamport-5pkjd5. 27 new tests (150 total green), security review clean."
+    2-2-llm-client-abstraction:
       status: ready-for-dev
-      notes: "Story file created 2026-06-30. Reconciled 2026-07-01 — was incorrectly showing 'backlog'. story.yaml was stale vs sprint-status.yaml."
+      notes: "Inserted 2026-07-02 before drift engine — prerequisite for 2.3/2.4 LLM calls. Synced from sprint-status.yaml 2026-07-04."
     2-2-drift-engine: { status: backlog }
     2-3-reporting-agent: { status: backlog }
     2-4-monitoring-agent-alert-delivery: { status: backlog }
@@ -115,8 +119,8 @@ epic_7:
     7-5-versioned-rest-api-webhooks: { status: backlog }
 
 summary:
-  total_stories: 31
-  done: 6
+  total_stories: 32  # +1: 2-2-llm-client-abstraction inserted 2026-07-02
+  done: 7
   review: 0
   in_progress: 0
   ready_for_dev: 1

--- a/uv.lock
+++ b/uv.lock
@@ -132,6 +132,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/35/96ad0a71eb0b27ab4476a7ed23facd0713d82da9c911edc8af7f34a62d6a/croniter-6.2.3.tar.gz", hash = "sha256:fb129986ef7e2c44e3f4c9f503da83ad914d2afa48f40a43ee3dca4b5c41d476", size = 166174, upload-time = "2026-07-02T14:34:22.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/dd/6466498a8b69754cffbd7237ce4c66446ca5ffcf53fb397d437666f056d2/croniter-6.2.3-py3-none-any.whl", hash = "sha256:137a97001b4d52fb71c10b750e303db79e6e42d40fff8ff77126102176c9f786", size = 46446, upload-time = "2026-07-02T14:34:20.889Z" },
+]
+
+[[package]]
 name = "cssselect2"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -142,6 +154,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -156,6 +177,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/b4/4435f3fcb1357ec441079c4af1dda3ea926fad6dcead4aed2d93b369944e/docxtpl-0.20.2.tar.gz", hash = "sha256:eddf3350d70b4d123208e801d585bcb313d21044a377a14f75a66d0965841de1", size = 17890, upload-time = "2025-11-13T12:47:15.943Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ad/e07939d8e020e513d3860400413ba1e0e06102c469639b440d921337efef/docxtpl-0.20.2-py3-none-any.whl", hash = "sha256:626d5c570a46a62b2ca73b4d08f1c240fa031a5bc45371e1466a4fe184923d10", size = 17881, upload-time = "2025-11-13T12:47:13.704Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -196,6 +230,15 @@ woff = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
     { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
     { name = "zopfli" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -620,6 +663,51 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -637,10 +725,14 @@ name = "savvycortex"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "croniter" },
     { name = "docxtpl" },
+    { name = "email-validator" },
     { name = "jinja2" },
     { name = "pandas" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "structlog" },
     { name = "typer" },
     { name = "weasyprint" },
@@ -648,10 +740,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "croniter", specifier = ">=2.0" },
     { name = "docxtpl", specifier = ">=0.20.2" },
+    { name = "email-validator", specifier = ">=2.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "typer", specifier = ">=0.12.1" },
     { name = "weasyprint", specifier = ">=68.1" },


### PR DESCRIPTION
## Summary

Implements the Phase 2 configuration layer (Story 2.1) with a complete Pydantic-based schema for pipeline configuration. Introduces typed configuration contracts, environment-variable-based secret management, and comprehensive validation with detailed error reporting.

## Key Changes

- **New `backend/models/pipeline_config.py`**: Defines the complete configuration schema with Pydantic v2 models:
  - `ScheduleConfig`: Validates either a named interval (daily/weekly/monthly) or a cron expression (via croniter), but never both
  - `OutputConfig`: Report format (docx/pdf) and output directory settings
  - `SmtpSettings`: SMTP credentials sourced exclusively from environment variables, never from YAML
  - `PipelineConfig`: Root model composing all sub-configs with a stateless `load()` classmethod that re-reads and re-validates on every call (FR10)
  - Comprehensive validation: positive thresholds, valid email addresses, forbidden YAML keys (smtp/secrets/credentials/api_keys), and proper error wrapping

- **Updated `backend/pipeline/config.py`**: Replaced the empty dataclass stub with a re-export of `PipelineConfig` from `backend.models.pipeline_config`, preserving existing logging functions (`configure_logging`, `bind_pipeline_run_id`)

- **New `config.yaml`**: Example configuration at repo root with documented sections for data sources, report schedule, metric thresholds, alert recipients, and output settings. No secrets included.

- **Comprehensive test suite** (`backend/tests/test_config.py`): 27 tests covering:
  - Valid configuration loading with type conversion and defaults
  - All validation error paths (missing fields, malformed cron, invalid thresholds, bad emails, forbidden YAML keys, missing/unparseable files)
  - Environment variable secret sourcing for SMTP credentials
  - Stateless reload behavior (FR10)
  - Observability: `config_loaded` structlog event with no secrets or PII in the payload
  - Re-export verification and schedule description formatting

- **Dependencies**: Added `pyyaml>=6.0`, `croniter>=2.0`, `email-validator>=2.0`, and `python-dotenv>=1.0` to both `pyproject.toml` and `backend/requirements.txt`

- **Environment setup**: Updated `.env.example` with SMTP configuration variables under a Phase 2 alert delivery header

## Notable Implementation Details

- **Secrets discipline (NFR3)**: SMTP credentials are sourced exclusively from environment variables via `SmtpSettings.env_values()` and are never permitted in `config.yaml`. The loader explicitly rejects any forbidden YAML keys.
- **Stateless design (FR10)**: `PipelineConfig.load()` re-reads and re-validates the file on every call with no caching, allowing scheduled agents to pick up on-disk changes without process restart.
- **Error handling**: All exceptions (ValidationError, YAMLError, FileNotFoundError) are wrapped in `ConfigurationError` with descriptive messages; pydantic ValidationError never escapes.
- **Observability**: Emits a `config_loaded` structlog event with schedule, threshold keys, recipient count, and output format — but never includes secret values, API keys, or email addresses (PII-adjacent).
- **JSON support**: Uses `yaml.safe_load()` which parses JSON as a valid YAML subset, eliminating the need for separate JSON handling.

https://claude.ai/code/session_01EZTuHcab1j1gurXMoDMvXK