### PR TITLE
feat(core): Epic 2 foundation — LLM client abstraction, config layer, Drift Engine story

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,10 @@ SUPABASE_SERVICE_ROLE_KEY=
 # Frontend equivalents (Vite reads VITE_*-prefixed vars)
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
+
+# SMTP — Phase 2 alert delivery
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_FROM=

--- a/_bmad-output/implementation-artifacts/2-1-configuration-layer.md
+++ b/_bmad-output/implementation-artifacts/2-1-configuration-layer.md
@@ -1,6 +1,6 @@
 # Story 2.1: Configuration Layer
 
-Status: ready-for-dev
+Status: done
 
 <!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
 
@@ -60,52 +60,52 @@ so that agents can be configured without code changes and settings can be modifi
 
 ## Tasks / Subtasks
 
-- [ ] **Task 0 — Resolve schema location & read the existing stub** (AC: 1, 3)
-  - [ ] Read `backend/pipeline/config.py` — it currently holds `configure_logging()`,
+- [x] **Task 0 — Resolve schema location & read the existing stub** (AC: 1, 3)
+  - [x] Read `backend/pipeline/config.py` — it currently holds `configure_logging()`,
         `bind_pipeline_run_id()`, and a **stub stdlib `@dataclass PipelineConfig`** (empty). Do NOT
         delete the logging functions — `conftest.py:20` imports `configure_logging` from here and the
         whole suite depends on it.
-  - [ ] Follow the prescribed resolution in Dev Notes: define the Pydantic models in
+  - [x] Follow the prescribed resolution in Dev Notes: define the Pydantic models in
         `backend/models/pipeline_config.py`; replace the stub in `pipeline/config.py` with a
         re-export so `from backend.pipeline.config import PipelineConfig` keeps working.
 
-- [ ] **Task 1 — Define the Pydantic config contract** `backend/models/pipeline_config.py` (AC: 1, 2)
-  - [ ] `ThresholdConfig` (or a `dict[str, float]` field with a validator) — per-metric fractional
+- [x] **Task 1 — Define the Pydantic config contract** `backend/models/pipeline_config.py` (AC: 1, 2)
+  - [x] `ThresholdConfig` (or a `dict[str, float]` field with a validator) — per-metric fractional
         thresholds; default `DEFAULT_THRESHOLD = 0.15`; every value must be `> 0` (reject negative/zero).
-  - [ ] `ScheduleConfig` — accepts either an interval enum (`daily`/`weekly`/`monthly`) or a cron
+  - [x] `ScheduleConfig` — accepts either an interval enum (`daily`/`weekly`/`monthly`) or a cron
         string; validate cron via `croniter` (raise on malformed). Exactly one of interval/cron.
-  - [ ] `DataSourceConfig` — list of file paths or directories (non-empty list of `str`/`Path`).
-  - [ ] `OutputConfig` — `format` (`docx`/`pdf`, default `docx`), `output_dir` (default `output/`).
-  - [ ] `AlertConfig` — `recipients: list[EmailStr]` (validate email format via Pydantic `EmailStr`).
-  - [ ] Root `PipelineConfig(BaseModel)` composing the above, plus a `@classmethod load(cls, path: str
+  - [x] `DataSourceConfig` — list of file paths or directories (non-empty list of `str`/`Path`).
+  - [x] `OutputConfig` — `format` (`docx`/`pdf`, default `docx`), `output_dir` (default `output/`).
+  - [x] `AlertConfig` — `recipients: list[EmailStr]` (validate email format via Pydantic `EmailStr`).
+  - [x] Root `PipelineConfig(BaseModel)` composing the above, plus a `@classmethod load(cls, path: str
         | Path | None = None) -> "PipelineConfig"` that reads YAML, merges env-sourced secrets, and
         validates. Use `model_config = ConfigDict(...)` per Pydantic v2.
 
-- [ ] **Task 2 — Implement the loader** `PipelineConfig.load()` (AC: 2, 3, 4, 5, 6)
-  - [ ] Default path = `config.yaml` at project root; accept an explicit path for tests.
-  - [ ] Parse with `yaml.safe_load` (PyYAML). JSON is a valid subset — `safe_load` reads `.json` too;
+- [x] **Task 2 — Implement the loader** `PipelineConfig.load()` (AC: 2, 3, 4, 5, 6)
+  - [x] Default path = `config.yaml` at project root; accept an explicit path for tests.
+  - [x] Parse with `yaml.safe_load` (PyYAML). JSON is a valid subset — `safe_load` reads `.json` too;
         no separate JSON branch needed (note this in a comment).
-  - [ ] Call `load_dotenv()` (python-dotenv) then read `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`,
+  - [x] Call `load_dotenv()` (python-dotenv) then read `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`,
         `SMTP_PASSWORD`, `SMTP_FROM` from `os.environ`. Surface them on the typed config (e.g., an
         `SmtpSettings` sub-object) — but they originate ONLY from env, never from the YAML.
-  - [ ] Wrap `pydantic.ValidationError`, `yaml.YAMLError`, and `FileNotFoundError` in
+  - [x] Wrap `pydantic.ValidationError`, `yaml.YAMLError`, and `FileNotFoundError` in
         `ConfigurationError` with a descriptive message (AC2). Re-read on every call (AC5 — no caching).
-  - [ ] Emit `structlog.get_logger().info("config_loaded", schedule=..., threshold_keys=...,
+  - [x] Emit `structlog.get_logger().info("config_loaded", schedule=..., threshold_keys=...,
         recipient_count=..., output_format=...)` — **assert no secret values are in the log payload.**
 
-- [ ] **Task 3 — Replace the stub & wire exports** `backend/pipeline/config.py` (AC: 3)
-  - [ ] Remove the empty `@dataclass PipelineConfig`; add `from backend.models.pipeline_config import
+- [x] **Task 3 — Replace the stub & wire exports** `backend/pipeline/config.py` (AC: 3)
+  - [x] Remove the empty `@dataclass PipelineConfig`; add `from backend.models.pipeline_config import
         PipelineConfig` (re-export) so both import paths resolve to the one Pydantic model.
-  - [ ] Update the module docstring: the "full config surface lands in Story 1.6" note is stale —
+  - [x] Update the module docstring: the "full config surface lands in Story 1.6" note is stale —
         replace with "config schema defined in Story 2.1; see `backend/models/pipeline_config.py`".
-  - [ ] Keep `configure_logging()` and `bind_pipeline_run_id()` exactly as-is.
+  - [x] Keep `configure_logging()` and `bind_pipeline_run_id()` exactly as-is.
 
-- [ ] **Task 4 — Author `config.yaml` + update `.env.example` + `pyproject.toml`** (AC: 1, 4)
-  - [ ] Create `config.yaml` at repo root with a documented, working example (see Dev Notes for the
+- [x] **Task 4 — Author `config.yaml` + update `.env.example` + `pyproject.toml`** (AC: 1, 4)
+  - [x] Create `config.yaml` at repo root with a documented, working example (see Dev Notes for the
         canonical shape). Comment each section. NO secrets in it.
-  - [ ] Add to `.env.example`: `SMTP_HOST=`, `SMTP_PORT=587`, `SMTP_USERNAME=`, `SMTP_PASSWORD=`,
+  - [x] Add to `.env.example`: `SMTP_HOST=`, `SMTP_PORT=587`, `SMTP_USERNAME=`, `SMTP_PASSWORD=`,
         `SMTP_FROM=` under a `# SMTP — Phase 2 alert delivery` header.
-  - [ ] Add deps to **both** `pyproject.toml` `dependencies` **and** `backend/requirements.txt`:
+  - [x] Add deps to **both** `pyproject.toml` `dependencies` **and** `backend/requirements.txt`:
         `pyyaml>=6.0`, `croniter>=2.0`, `email-validator>=2.0` (required by Pydantic `EmailStr`), and
         reconcile `python-dotenv>=1.0` (already in `requirements.txt`, **missing from `pyproject.toml`** —
         add it there). The two files are hand-maintained and already drift (`docxtpl`/`weasyprint`/
@@ -114,16 +114,16 @@ so that agents can be configured without code changes and settings can be modifi
         the four config deps land in both. Verify with:
         `grep -iE 'pyyaml|croniter|email-validator|python-dotenv' pyproject.toml backend/requirements.txt`
 
-- [ ] **Task 5 — Tests** `backend/tests/test_config.py` (AC: 2, 3, 4, 5, 6)
-  - [ ] Valid config → typed `PipelineConfig`, defaults applied (threshold `0.15`, format `docx`).
-  - [ ] Missing required field → `ConfigurationError` (not bare `ValidationError`).
-  - [ ] Invalid values: malformed cron, negative threshold, bad email → each raises `ConfigurationError`.
-  - [ ] Env override: set `SMTP_PASSWORD` via `monkeypatch.setenv`, assert it lands on the config and
+- [x] **Task 5 — Tests** `backend/tests/test_config.py` (AC: 2, 3, 4, 5, 6)
+  - [x] Valid config → typed `PipelineConfig`, defaults applied (threshold `0.15`, format `docx`).
+  - [x] Missing required field → `ConfigurationError` (not bare `ValidationError`).
+  - [x] Invalid values: malformed cron, negative threshold, bad email → each raises `ConfigurationError`.
+  - [x] Env override: set `SMTP_PASSWORD` via `monkeypatch.setenv`, assert it lands on the config and
         is absent from any YAML on disk.
-  - [ ] Reload: write `config.yaml` to `tmp_path`, `load()`, mutate the file, `load()` again, assert
+  - [x] Reload: write `config.yaml` to `tmp_path`, `load()`, mutate the file, `load()` again, assert
         the second instance reflects the change.
-  - [ ] Use `tmp_path` for all file I/O — never write to the real repo-root `config.yaml`.
-  - [ ] Capture logs (e.g., `structlog` testing capture or `caplog`) and assert `config_loaded` fires
+  - [x] Use `tmp_path` for all file I/O — never write to the real repo-root `config.yaml`.
+  - [x] Capture logs (e.g., `structlog` testing capture or `caplog`) and assert `config_loaded` fires
         and the payload contains no secret values.
 
 ## Dev Notes
@@ -297,8 +297,81 @@ output:
 
 ### Agent Model Used
 
+Claude Sonnet 5.
+
 ### Debug Log References
+
+- `uv run pytest backend/tests/test_config.py -v` → 18 passed.
+- `uv run pytest backend/tests/ --ignore=backend/tests/test_parse_file.py` → 133 passed, 1 skipped (pre-existing, unrelated `anthropic`-missing skip), zero regressions.
+- `grep -inE 'pyyaml|croniter|email-validator|python-dotenv' pyproject.toml backend/requirements.txt` → all four present in both files (Task 4 verification command).
 
 ### Completion Notes List
 
+- **Stale story assumption (Task 0 / Dev Notes):** the story's Task 0 and "Existing
+  code you are extending" section assume `backend/pipeline/config.py` still holds
+  `configure_logging()`/`bind_pipeline_run_id()` and that `conftest.py:20` imports
+  `configure_logging` from there. That was true when this story was drafted, but
+  **Story 2.2b** (shipped same day, before this story started) already moved both
+  functions into `backend/core/logging.py` and trimmed `pipeline/config.py` down to
+  the empty `PipelineConfig` stub — `conftest.py` now imports `configure_logging`
+  from `backend.core.logging`. This made Task 0/Task 3's "don't delete the logging
+  functions" instruction moot: there was nothing logging-related left in
+  `pipeline/config.py` to preserve. Implemented against the actual on-disk state,
+  not the story's now-stale snapshot — `pipeline/config.py` was replaced with a
+  pure re-export of `PipelineConfig` from `backend.models.pipeline_config`, per the
+  prescribed resolution, with no logging-function collision to manage.
+- **AC1/AC3** — `backend/models/pipeline_config.py` defines `ThresholdConfig`,
+  `ScheduleConfig`, `DataSourceConfig`, `OutputConfig`, `AlertConfig`,
+  `SmtpSettings`, and root `PipelineConfig(BaseModel)` with `load(path=None)`.
+  `backend/pipeline/config.py` re-exports `PipelineConfig` so both import paths
+  resolve to the one model.
+- **AC2** — `load()` wraps `FileNotFoundError`, `yaml.YAMLError`, a malformed
+  `SMTP_PORT` env var, and `pydantic.ValidationError` into `ConfigurationError`;
+  no raw exception escapes the loader. Field-level validators reject non-cron
+  strings, non-`daily`/`weekly`/`monthly` intervals, both-or-neither
+  interval/cron, non-positive thresholds, and malformed emails (via
+  `EmailStr`).
+- **AC4** — `SmtpSettings` is populated exclusively from `os.environ` inside
+  `load()`, overwriting any `smtp` key that might appear in the YAML; `config.yaml`
+  has zero secret fields. `.env.example` documents `SMTP_HOST`/`PORT`/`USERNAME`/
+  `PASSWORD`/`FROM`.
+- **AC5** — `load()` re-reads and re-validates the file on every call (no
+  `functools.lru_cache`, no module/class-level cache) — verified by a dedicated
+  reload test and confirmed in a follow-up code review.
+- **AC6** — `structlog.get_logger().info("config_loaded", schedule=..., threshold_keys=...,
+  recipient_count=..., output_format=...)` fires on every load; never logs SMTP
+  credentials or the recipient list (count only).
+- **Deps** — `pyyaml`, `croniter`, `email-validator` added (all new); `python-dotenv`
+  reconciled into `pyproject.toml` (was requirements.txt-only). Pre-existing
+  pyproject/requirements.txt drift for unrelated packages was left untouched, per
+  the story's explicit instruction.
+- **Post-implementation code review finding, fixed same session:** the
+  `model_validator(mode="before")` wrappers on `DataSourceConfig`/`AlertConfig`
+  (which accept the YAML's flat-list shape for `data_sources`/`alert_recipients`)
+  only checked `isinstance(data, list)`. A YAML indentation mistake producing a
+  mapping instead of a list (e.g. `data_sources:\n  file: data/sales.csv`) fell
+  through unwrapped, and because both fields have `default_factory=list`,
+  Pydantic silently applied the empty-list default instead of raising —
+  `config_loaded` would fire as if the config were valid, with zero data sources
+  or recipients and no error. Fixed by rejecting a **non-empty** dict that lacks
+  the expected key (`paths`/`recipients`), while still allowing the **empty**
+  dict through unchanged (the legitimate default-construction path when the
+  field is absent from the parent config entirely). Two regression tests added:
+  `test_data_sources_as_mapping_raises_configuration_error` and
+  `test_alert_recipients_as_mapping_raises_configuration_error`.
+
 ### File List
+
+- `backend/models/pipeline_config.py` (new)
+- `backend/pipeline/config.py` (modified — stub replaced with re-export)
+- `config.yaml` (new, repo root)
+- `.env.example` (modified — +SMTP placeholders)
+- `pyproject.toml` (modified — +4 deps)
+- `backend/requirements.txt` (modified — same 4 deps, mirrored)
+- `backend/tests/test_config.py` (new, 18 tests)
+
+## Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-05 | Implemented: `backend/models/pipeline_config.py` Pydantic config contract, `config.yaml`, `.env.example` SMTP placeholders, 4 new deps, 18 tests. 133 passed / 1 skipped, zero regressions. Scoped code review found and fixed a silent-swallow bug in the `data_sources`/`alert_recipients` mapping-vs-list validators. Status → done. |

--- a/_bmad-output/implementation-artifacts/2-2-llm-client-abstraction.md
+++ b/_bmad-output/implementation-artifacts/2-2-llm-client-abstraction.md
@@ -1,6 +1,6 @@
 # Story 2.2: LLM Client Abstraction
 
-Status: ready-for-dev
+Status: done
 
 > 🔌 **Inserted story — not yet in epics.md.** Filed out-of-band between 2.1
 > (Configuration Layer) and the original 2.2 (Drift Engine, now effectively 2.3 in
@@ -66,73 +66,73 @@ consolidated in one place rather than scattered across pipeline stages.
 
 ## Tasks / Subtasks
 
-- [ ] **Task 0 — Read the current implementation in full** (no AC, mandatory pre-work)
-  - [ ] Read `backend/pipeline/narrative_generator.py` completely — every method, every
+- [x] **Task 0 — Read the current implementation in full** (no AC, mandatory pre-work)
+  - [x] Read `backend/pipeline/narrative_generator.py` completely — every method, every
         constant, every import. The file is 287 lines. Do not skim.
-  - [ ] Read `backend/tests/test_narrative_generator.py` completely — identify every
+  - [x] Read `backend/tests/test_narrative_generator.py` completely — identify every
         mock target path that will change after the move. List them before writing
         a single line of new code.
-  - [ ] Read `backend/models/insight_payload.py`, `backend/models/insight_report.py`
+  - [x] Read `backend/models/insight_payload.py`, `backend/models/insight_report.py`
         — confirm the type contracts `LLMClient` will receive and return.
-  - [ ] Read `backend/errors/exceptions.py` — confirm `LLMProviderError` signature
+  - [x] Read `backend/errors/exceptions.py` — confirm `LLMProviderError` signature
         (takes `message: str`, `provider: str`, `cause: Exception`).
 
-- [ ] **Task 1 — Create `backend/core/__init__.py`** (AC: 5)
-  - [ ] Single line: `# backend/core — shared utilities (LLM client, future: cost tracking)`
-  - [ ] This is the only change to directory structure.
+- [x] **Task 1 — Create `backend/core/__init__.py`** (AC: 5)
+  - [x] Single line: `# backend/core — shared utilities (LLM client, future: cost tracking)`
+  - [x] This is the only change to directory structure.
 
-- [ ] **Task 2 — Create `backend/core/llm_client.py`** (AC: 1, 4, 6, 7)
-  - [ ] Move verbatim from `narrative_generator.py`:
+- [x] **Task 2 — Create `backend/core/llm_client.py`** (AC: 1, 4, 6, 7)
+  - [x] Move verbatim from `narrative_generator.py`:
         - Constants: `_BACKOFF_DELAYS`, `_MAX_ATTEMPTS`, `_CIRCUIT_BREAKER_THRESHOLD`,
           `_CLAUDE_MODEL`, `_OPENAI_MODEL`, `_GEMINI_MODEL`, `_SYSTEM_PROMPT`
         - Methods: `_call_claude`, `_call_openai`, `_call_gemini`, `_try_provider`,
           `_is_client_error`, `_build_report`, `_build_prompt`
         - All imports those methods require
-  - [ ] Define `class LLMClient:` with `__init__(self) -> None` that binds
+  - [x] Define `class LLMClient:` with `__init__(self) -> None` that binds
         `self._logger = structlog.get_logger().bind(stage="narrative_generator")`.
         **Keep `stage="narrative_generator"` in the logger binding** — changing it
         would alter structlog event payloads and break AC6.
-  - [ ] Public method: `def generate_narrative(self, payload_json: str, pipeline_run_id:
+  - [x] Public method: `def generate_narrative(self, payload_json: str, pipeline_run_id:
         str) -> InsightReport:` — this is the loop-and-fallback method currently named
         `generate()` in `NarrativeGenerator`, adapted to accept `payload_json` directly
         (the caller no longer passes an `InsightPayload` object — `narrative_generator.py`
         serializes it before calling).
-  - [ ] Module docstring: explain the resilience layers (copy from `narrative_generator.py`
+  - [x] Module docstring: explain the resilience layers (copy from `narrative_generator.py`
         docstring, update file reference).
 
-- [ ] **Task 3 — Refactor `backend/pipeline/narrative_generator.py`** (AC: 2, 6)
-  - [ ] Add import: `from backend.core.llm_client import LLMClient`
-  - [ ] In `__init__`: add `self._client = LLMClient()`
-  - [ ] Replace `generate()` body with:
-        ```python
-        bind_pipeline_run_id(pipeline_run_id)
-        payload_json = insight_payload.model_dump_json()
-        return self._client.generate_narrative(payload_json, pipeline_run_id)
-        ```
-  - [ ] Delete all moved constants and methods from this file.
-  - [ ] The remaining file should be ~25 lines: module docstring, imports
-        (`InsightPayload`, `InsightReport`, `LLMClient`, `bind_pipeline_run_id`),
+- [x] **Task 3 — Refactor `backend/pipeline/narrative_generator.py`** (AC: 2, 6)
+  - [x] Add import: `from backend.core.llm_client import LLMClient`
+  - [x] In `__init__`: add `self._client = LLMClient()`
+  - [x] Replace `generate()` body with serialize + delegate. (Deviation: `bind_pipeline_run_id`
+        moved into `LLMClient.generate_narrative` rather than the delegator, so the client is
+        self-contained for future direct callers — 2.3/2.4. Behavior identical; bind still
+        runs before any LLM log event.)
+  - [x] Delete all moved constants and methods from this file.
+  - [x] The remaining file is a thin shell: module docstring, imports
+        (`InsightPayload`, `InsightReport`, `LLMClient`),
         `NarrativeGenerator` class with `__init__` and `generate()` only.
-  - [ ] Update module docstring: note that resilience logic lives in
+  - [x] Update module docstring: note that resilience logic lives in
         `backend/core/llm_client.py` as of Story 2.2.
 
-- [ ] **Task 4 — Update mock targets in `backend/tests/test_narrative_generator.py`**
+- [x] **Task 4 — Update mock targets in `backend/tests/test_narrative_generator.py`**
       (AC: 3)
-  - [ ] Find every `@patch` or `mocker.patch` call. Current targets are of the form
-        `backend.pipeline.narrative_generator.NarrativeGenerator._call_claude` (or
-        similar). Update each to
-        `backend.core.llm_client.LLMClient._call_claude` (or the new path).
-  - [ ] Run `uv run pytest backend/tests/test_narrative_generator.py -v` — all tests
-        must pass before proceeding to Task 5.
-  - [ ] **Do not add, remove, or rewrite any test case.** Only update mock targets
-        and import paths.
+  - [x] Retargeted every `patch.object(gen, "_call_*")` and
+        `patch("backend.pipeline.narrative_generator.time.sleep")` to
+        `backend.core.llm_client.LLMClient._call_*` / `backend.core.llm_client.time.sleep`.
+        The `_call_claude` provider-body test now exercises an `LLMClient()` instance
+        (the method's new home). Added `from backend.core.llm_client import LLMClient`.
+  - [x] Run `uv run pytest backend/tests/test_narrative_generator.py -v` — all tests
+        pass (11 passed, 1 skipped for missing `anthropic`).
+  - [x] **Do not add, remove, or rewrite any test case.** Only mock targets, the object
+        under test for the `_call_claude` body test, and the import were changed —
+        no assertion was altered.
 
-- [ ] **Task 5 — Full suite regression** (AC: 3, 6)
-  - [ ] Run `uv run pytest backend/tests/ -v`
-  - [ ] All 111 previously-passing tests must still pass (1 skip for `anthropic`
-        missing from env is expected and acceptable).
-  - [ ] Zero new failures. If any test fails, fix the mock target — do not alter
-        the test's assertions.
+- [x] **Task 5 — Full suite regression** (AC: 3, 6)
+  - [x] Ran `uv run pytest backend/tests/ --ignore=backend/tests/test_parse_file.py`
+        (`test_parse_file.py` fails to collect on a pre-existing missing-`fastapi`
+        dependency, unrelated to this story).
+  - [x] 111 passed, 1 skipped (`anthropic` missing) — identical to the pre-change baseline.
+  - [x] Zero new failures.
 
 ## Dev Notes
 
@@ -276,8 +276,62 @@ update those too.
   models in this story; `InsightReport` and `NarrativeContent` are already defined
   in `backend/models/`
 
+## Dev Agent Record
+
+### Implementation Plan
+
+Pure internal extraction — no behavior change, no new dependencies. The 287-line
+`narrative_generator.py` held the retry/fallback/circuit-breaker loop, three
+`_call_*` provider methods, resilience constants, and the `_SYSTEM_PROMPT`. All of
+it moved verbatim into `backend/core/llm_client.py` as `class LLMClient`, with the
+loop method renamed `generate()` → `generate_narrative(payload_json, pipeline_run_id)`.
+`NarrativeGenerator` became a ~37-line Stage-3 adapter that serializes the payload and
+delegates to `self._client`. Tests were repointed at the methods' new home.
+
+### Completion Notes
+
+- **AC1** — `backend/core/llm_client.py` exists; `LLMClient.generate_narrative()` runs the
+  full resilience chain (retry ×3, backoff 1/2/4s, Claude→OpenAI→Gemini fallback, circuit
+  breaker at 3) and returns an `InsightReport`.
+- **AC2** — `NarrativeGenerator` is a thin delegator; all `_call_*`/`_try_provider`/
+  `_is_client_error`/`_build_report`/`_build_prompt` methods and the resilience constants
+  moved to `LLMClient`. `__init__` binds `self._client = LLMClient()` (per-instance, not a
+  singleton — matches other stages).
+- **AC3** — `test_narrative_generator.py` passes unchanged in substance; only mock targets,
+  the object-under-test for the provider-body test, and one import were updated.
+- **AC4** — `_CLAUDE_MODEL`/`_OPENAI_MODEL`/`_GEMINI_MODEL` (and all other constants) now
+  live once, in `llm_client.py`. Zero duplication in `narrative_generator.py`.
+- **AC5** — `backend/core/__init__.py` created (1 comment line).
+- **AC6** — `stage="narrative_generator"` logger binding and all event names
+  (`narrative_generated`, `llm_fallback`, `llm_retry`, `llm_client_error`,
+  `llm_circuit_breaker`) preserved byte-for-byte; log-asserting tests pass without
+  assertion changes.
+- **AC7** — No new dependency added to `pyproject.toml`. `anthropic`/`openai`/
+  `google.genai` remain lazy imports inside their `_call_*` methods.
+- **Design deviation (documented):** `bind_pipeline_run_id(pipeline_run_id)` was placed
+  inside `generate_narrative` rather than the delegator (Task 3's illustrative pseudo-code
+  showed it in the delegator). This makes `LLMClient` self-contained for the future direct
+  callers the story anticipates (2.3/2.4). Behavior is identical — the bind still runs
+  before any provider call or log event.
+- **Out-of-scope observation (not changed):** `backend/nlp_processor.py` has top-level
+  `import anthropic`/`openai`/`google.generativeai`. It is a pre-existing legacy module
+  unrelated to the narrative pipeline and outside this story's scope. A future
+  provider-import compliance gate would need to address or exempt it.
+- **Pre-existing env gap (not caused by this story):** `backend/tests/test_parse_file.py`
+  cannot collect because `fastapi` is not installed; `fastapi` is not in `pyproject.toml`.
+  Excluded from the regression run.
+
+### File List
+
+- `backend/core/__init__.py` (new)
+- `backend/core/llm_client.py` (new)
+- `backend/pipeline/narrative_generator.py` (modified — reduced to thin delegator)
+- `backend/tests/test_narrative_generator.py` (modified — mock targets + import repointed)
+
 ## Change Log
 
 | Date | Change |
 |---|---|
 | 2026-07-02 | Story filed out-of-band between 2.1 and original 2.2 (Drift Engine). Rationale: 2.3 Reporting Agent and 2.4 Monitoring Agent require LLM calls; extraction prevents duplication. |
+| 2026-07-05 | Implemented: extracted resilience logic to `backend/core/llm_client.py`; `NarrativeGenerator` now delegates. 111 passed / 1 skipped, zero regressions. Status → review. |
+| 2026-07-05 | Code review (scoped question: does the `bind_pipeline_run_id` placement create hidden coupling for 2.3/2.4?) found three issues — core→pipeline import leak, unguaranteed JSON logging for direct callers, unscoped contextvar binding. Filed and shipped as corrective Story 2.2b. Status → done. |

--- a/_bmad-output/implementation-artifacts/2-2b-harden-llm-client-multi-caller.md
+++ b/_bmad-output/implementation-artifacts/2-2b-harden-llm-client-multi-caller.md
@@ -1,0 +1,239 @@
+# Story 2.2b: Harden LLMClient for Multi-Caller Use
+
+Status: done
+
+> 🔧 **Corrective story — filed from code review of Story 2.2.** The 2.2 code review
+> (scoped question: "does the self-contained `bind_pipeline_run_id` placement create
+> hidden coupling for the direct callers 2.3/2.4 will introduce?") confirmed three
+> concrete issues in `backend/core/llm_client.py`. Story 2.2's own behavior
+> (single caller: `NarrativeGenerator` via `orchestrator.py`) is unaffected and stays
+> shipped — this story hardens `LLMClient` before Reporting Agent (2.3) and Monitoring
+> Agent (2.4) become direct callers.
+
+## Story
+
+As a developer,
+I want `LLMClient` decoupled from `backend/pipeline/` and safe under direct,
+repeated, or concurrent invocation,
+so that the Reporting Agent (2.3) and Monitoring Agent (2.4) can call it without
+inheriting pipeline-package internals, without silently losing JSON log output, and
+without leaking `pipeline_run_id` into unrelated log lines on a reused thread/task.
+
+## Acceptance Criteria
+
+1. **`backend/core/llm_client.py` no longer imports from `backend/pipeline/`.**
+   The shared logging/context-binding primitives (`configure_logging`,
+   `bind_pipeline_run_id`) move to a new `backend/core/logging.py`.
+   `backend/pipeline/config.py` retains only `PipelineConfig`. Every existing call
+   site (`orchestrator.py`, `llm_client.py`, `conftest.py`, `test_insight_engine.py`,
+   `test_narrative_generator.py`) imports from the new location. No change to what
+   gets logged or how — this is a pure move.
+
+2. **JSON logging is guaranteed for callers who never call `configure_logging()`,
+   without clobbering callers/tests who already configured structlog.** Given
+   structlog is already configured (e.g. a test's `LogCapture` fixture, or a caller's
+   own prior `configure_logging()` call), when `LLMClient.generate_narrative()` runs,
+   then it must NOT reconfigure structlog (existing processor chain — including test
+   capture processors — must survive the call untouched). Given structlog is
+   unconfigured (a bare direct call with no setup, e.g. a future agent that forgets
+   the setup step), when `generate_narrative()` runs, then it must configure JSON
+   logging itself so `narrative_generated` / `llm_fallback` / `llm_retry` /
+   `llm_client_error` / `llm_circuit_breaker` events are emitted as JSON, not the
+   structlog default renderer.
+
+3. **`pipeline_run_id` binding is scoped to the call, not leaked to the ambient
+   context.** `LLMClient.generate_narrative()` must restore whatever contextvars
+   state existed before the call once it returns (success or exception) — a
+   subsequent, unrelated log line on the same thread/asyncio task must never carry a
+   stale `pipeline_run_id` from a prior call. This must NOT break the existing
+   single-caller pipeline flow: `orchestrator.py` binds `pipeline_run_id` once at the
+   top of `run_full_pipeline()` and expects Stage 4 (render) logs, which run *after*
+   `NarrativeGenerator.generate()` returns, to still carry that same
+   `pipeline_run_id`. The fix must restore the orchestrator's own outer binding, not
+   clear it to nothing.
+
+4. **No regressions.** All existing tests pass with only import-path changes — no
+   test assertion is added, removed, or altered in `test_narrative_generator.py`,
+   `test_insight_engine.py`, or `conftest.py` beyond the import statement. New tests
+   added for AC2 and AC3 (see Tasks). Full suite green.
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Create `backend/core/logging.py`** (AC: 1, 2, 3)
+  - [x] Move `configure_logging()` and `bind_pipeline_run_id()` verbatim from
+        `backend/pipeline/config.py` (docstrings included).
+  - [x] Add `ensure_logging_configured() -> None`: calls `configure_logging()` only
+        if `structlog.is_configured()` is `False`. This is the guard that satisfies
+        AC2 without clobbering an already-configured caller or test.
+  - [x] Add `scoped_pipeline_run_id(run_id: str)` — a `@contextlib.contextmanager`
+        wrapping `structlog.contextvars.bound_contextvars(pipeline_run_id=run_id)`.
+        `bound_contextvars` snapshots the current contextvars state on entry and
+        restores exactly that snapshot on exit (whether the block raises or not) —
+        this is what satisfies AC3 without any bespoke restore logic.
+  - [x] Module docstring: state this module is the shared logging/context-binding
+        primitive for both `pipeline/` and `agents/` — neither layer should import
+        logging setup from the other.
+
+- [x] **Task 2 — Trim `backend/pipeline/config.py`** (AC: 1)
+  - [x] Remove `configure_logging()` and `bind_pipeline_run_id()` (now in
+        `backend/core/logging.py`).
+  - [x] Keep `PipelineConfig` dataclass unchanged.
+  - [x] Update module docstring: the logging discipline notes now point to
+        `backend/core/logging.py`; this file is pipeline-run configuration only.
+
+- [x] **Task 3 — Update `backend/core/llm_client.py`** (AC: 1, 2, 3)
+  - [x] Replace `from backend.pipeline.config import bind_pipeline_run_id` with
+        `from backend.core.logging import ensure_logging_configured, scoped_pipeline_run_id`.
+  - [x] At the top of `generate_narrative()`, call `ensure_logging_configured()`.
+  - [x] Wrap the existing method body (from the provider loop through the
+        circuit-breaker fallback return) in
+        `with scoped_pipeline_run_id(pipeline_run_id):`. Indent only — no logic
+        changes.
+
+- [x] **Task 4 — Update `backend/pipeline/orchestrator.py`** (AC: 1)
+  - [x] Change `from backend.pipeline.config import bind_pipeline_run_id, configure_logging`
+        to `from backend.core.logging import bind_pipeline_run_id, configure_logging`.
+        No other change — orchestrator keeps its whole-run (unscoped) binding at line
+        ~86; that's correct for a one-shot CLI process and must not become scoped.
+
+- [x] **Task 5 — Update test imports** (AC: 1, 4)
+  - [x] `backend/tests/conftest.py`, `backend/tests/test_insight_engine.py`,
+        `backend/tests/test_narrative_generator.py`: change
+        `from backend.pipeline.config import configure_logging` to
+        `from backend.core.logging import configure_logging`. No other changes.
+
+- [x] **Task 6 — New tests: `backend/tests/test_llm_client_hardening.py`** (AC: 2, 3)
+  - [x] Test: with structlog already configured via `LogCapture` (mirror the
+        `log_capture` fixture pattern in `test_narrative_generator.py`), call
+        `LLMClient().generate_narrative(...)` with `_call_claude` mocked to succeed;
+        assert `log_capture.entries` contains the `narrative_generated` event —
+        proving `ensure_logging_configured()` did not reconfigure structlog and blow
+        away the capture processor.
+  - [x] Test: reset structlog to unconfigured (`structlog.reset_defaults()` or
+        equivalent) before the call; after calling `generate_narrative()`, assert
+        `structlog.is_configured()` is `True` — proving the guard configures JSON
+        logging when nothing else has.
+  - [x] Test: bind an unrelated contextvar (or leave contextvars empty) before
+        calling `generate_narrative(..., pipeline_run_id="run-A")`; after the call
+        returns, assert `structlog.contextvars.get_contextvars()` no longer contains
+        `pipeline_run_id` (or has been restored to its pre-call value) — proving
+        AC3's scoped restore.
+  - [x] Test: simulate the orchestrator pattern — call
+        `bind_pipeline_run_id("run-B")` first (outer, whole-run binding), then call
+        `LLMClient().generate_narrative(..., pipeline_run_id="run-B")`; after it
+        returns, assert `pipeline_run_id` is STILL `"run-B"` in the ambient
+        context — proving the scoped restore does not clear the orchestrator's own
+        outer binding (this is the regression guard architecture.md/Stage 4 needs).
+
+- [x] **Task 7 — Full suite regression** (AC: 4)
+  - [x] Run `uv run pytest backend/tests/ --ignore=backend/tests/test_parse_file.py`
+        (pre-existing `fastapi`-missing collection failure, unrelated).
+  - [x] All previously-passing tests still pass; new tests from Task 6 pass; zero
+        new failures.
+
+## Dev Notes
+
+### Why not just clear contextvars unconditionally after the call?
+
+`structlog.contextvars.clear_contextvars()` would wipe *all* bound contextvars, not
+just `pipeline_run_id` — and it would also break `orchestrator.py`'s existing
+single-caller usage, where `pipeline_run_id` is bound once for the whole
+`run_full_pipeline()` run and must still be present for Stage 4 (render) logging
+after `NarrativeGenerator.generate()` (→ `LLMClient.generate_narrative()`) returns.
+`structlog.contextvars.bound_contextvars(...)` is the correct primitive: it snapshots
+and restores only the keys it touches, in a `try/finally`, which is exactly "restore
+what was there before" rather than "wipe everything."
+
+### Why not just have `LLMClient` unconditionally call `configure_logging()`?
+
+`test_narrative_generator.py`'s `log_capture` fixture calls `structlog.configure()`
+itself (with a `LogCapture` processor) specifically so tests can assert on emitted
+events. If `generate_narrative()` unconditionally called `configure_logging()`, it
+would silently replace that processor chain mid-test and every log-assertion test
+would start failing (or silently stop capturing) the moment this story shipped.
+`structlog.is_configured()` is the correct guard — it's `True` once *any* caller
+(including a test fixture) has called `structlog.configure()`.
+
+### Layering — where `backend/core/` sits
+
+`architecture.md` §751-752: "`backend/pipeline/` is callable from both `api/` and
+`agents/` but imports from neither." `backend/core/` (added in Story 2.2, not in the
+original architecture target tree) is meant to be usable by both `pipeline/` and
+`agents/` — the whole reason `LLMClient` was extracted there. A module in `core/`
+importing from `pipeline/` inverts that: it means `agents/` (2.3, 2.4), which will
+import `backend.core.llm_client`, transitively depends on `backend.pipeline.config`
+for a concern (structured logging setup) that has nothing to do with the CSV
+pipeline. Moving `configure_logging`/`bind_pipeline_run_id` to `backend/core/logging.py`
+fixes the dependency direction: `pipeline/` and `agents/` both depend on `core/`,
+`core/` depends on neither.
+
+### Scope boundary
+
+This story does NOT touch the retry/fallback/circuit-breaker logic, the provider
+`_call_*` methods, or any structlog event name/field. Those are unchanged from
+Story 2.2. Do not "clean up while you're in there" beyond what the tasks specify.
+
+## Dev Agent Record
+
+### Implementation Plan
+
+Created `backend/core/logging.py` as the shared logging/context-binding primitive
+and moved `configure_logging`/`bind_pipeline_run_id` there verbatim, added
+`ensure_logging_configured()` (idempotent, guarded by `structlog.is_configured()`)
+and `scoped_pipeline_run_id()` (a context manager over
+`structlog.contextvars.bound_contextvars`). Trimmed `backend/pipeline/config.py`
+to just `PipelineConfig`. Repointed five import sites
+(`llm_client.py`, `orchestrator.py`, `conftest.py`, `test_insight_engine.py`,
+`test_narrative_generator.py`) at the new module. Wrapped
+`LLMClient.generate_narrative()`'s entire body in
+`with scoped_pipeline_run_id(pipeline_run_id):` and added an
+`ensure_logging_configured()` call at the top. Added
+`backend/tests/test_llm_client_hardening.py` with 4 new tests covering AC2 and AC3
+directly.
+
+### Completion Notes
+
+- **AC1** — `backend/core/llm_client.py` no longer imports anything from
+  `backend/pipeline/`; verified by grep (`select:pipeline` import search returned
+  empty for `backend/core/`). `backend/pipeline/config.py` retains only
+  `PipelineConfig`. All 5 call sites repointed.
+- **AC2** — `ensure_logging_configured()` guards on `structlog.is_configured()`.
+  New test `test_generate_narrative_preserves_log_capture` proves an
+  already-configured `LogCapture` survives the call; new test
+  `test_generate_narrative_configures_json_logging` proves JSON logging is
+  installed when nothing configured structlog first.
+- **AC3** — `scoped_pipeline_run_id` wraps `structlog.contextvars.bound_contextvars`,
+  which restores via `try/finally` on every exit path (including the
+  `LLMProviderError` re-raise and the `raise last_exc` inside `_try_provider`).
+  New test `test_pipeline_run_id_removed_after_call_with_no_prior_binding` proves
+  no leak for a bare direct call; new test
+  `test_pipeline_run_id_restored_after_call_with_prior_binding` proves the
+  orchestrator's whole-run binding survives Stage 3 (regression guard for Stage 4
+  render logging).
+- **AC4** — Full suite: 115 passed, 1 skipped (pre-existing `anthropic`-missing
+  skip), 0 failures — 111 from the pre-2.2b baseline + 4 new hardening tests.
+  `conftest.py`/`test_insight_engine.py`/`test_narrative_generator.py` changed only
+  their `configure_logging` import line.
+- **Verification:** a follow-up scoped code review of exactly these changes
+  (exception-safety of the context manager, completeness of the layering fix,
+  correctness of the `is_configured()` guard, orphaned old-import search, test
+  validity) returned zero findings.
+
+### File List
+
+- `backend/core/logging.py` (new)
+- `backend/core/llm_client.py` (modified — new import, `ensure_logging_configured()`
+  call, body wrapped in `scoped_pipeline_run_id`)
+- `backend/pipeline/config.py` (modified — trimmed to `PipelineConfig` only)
+- `backend/pipeline/orchestrator.py` (modified — import path only)
+- `backend/tests/conftest.py` (modified — import path only)
+- `backend/tests/test_insight_engine.py` (modified — import path only)
+- `backend/tests/test_narrative_generator.py` (modified — import path only)
+- `backend/tests/test_llm_client_hardening.py` (new)
+
+## Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-05 | Story filed as corrective follow-up to Story 2.2 code review (three findings: core→pipeline layering leak, unguaranteed JSON logging for direct callers, unscoped contextvar binding risking cross-call leakage). |
+| 2026-07-05 | Implemented: `backend/core/logging.py` added, `pipeline/config.py` trimmed, `LLMClient` scoped/guarded, 4 new hardening tests. 115 passed / 1 skipped, zero regressions. Follow-up scoped review: 0 findings. Status → done. |

--- a/_bmad-output/implementation-artifacts/2-3-drift-engine.md
+++ b/_bmad-output/implementation-artifacts/2-3-drift-engine.md
@@ -1,0 +1,398 @@
+# Story 2.3: Drift Engine
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+> 🔢 **Numbering reconciliation — epics.md sequence vs. actually-filed stories (READ FIRST for future
+> story creation).** epics.md's Epic 2 numbering has diverged from the real story history because an
+> LLM-client story was filed out-of-band (on 2026-07-02) as a hard prerequisite for the agents, taking
+> the `2.2` slot and pushing everything after it down by one. The **filed** numbering below is
+> authoritative — `sprint-status.yaml` and the story files on disk follow it, and epics.md's original
+> numbers should be read through this map, not literally:
+>
+> | epics.md original | Filed story (authoritative) | Status | Note |
+> |---|---|---|---|
+> | Story 2.1 — Configuration Layer | `2-1-configuration-layer` | done | 1:1 |
+> | — (no epics.md entry) | `2-2-llm-client-abstraction` | done | Inserted out-of-band 2026-07-02: LLM resilience extracted so 2.4/2.5 agents can call an LLM through one abstraction |
+> | — (no epics.md entry) | `2-2b-harden-llm-client-multi-caller-use` | done | Corrective follow-up from 2-2's code review (multi-caller hardening) |
+> | Story 2.2 — Drift Engine | **`2-3-drift-engine` (this story)** | ready-for-dev | Renumbered 2.2 → 2.3 |
+> | Story 2.3 — Reporting Agent | `2-4-reporting-agent` (not yet filed) | backlog | Renumbered 2.3 → 2.4 |
+> | Story 2.4 — Monitoring Agent & Alert Delivery | `2-5-monitoring-agent-alert-delivery` (not yet filed) | backlog | Renumbered 2.4 → 2.5 |
+>
+> When these ACs or Dev Notes cite "epics.md Story 2.2", that is **this** Drift Engine story. Citations
+> to the Reporting/Monitoring agents use their **filed** numbers (2.4 / 2.5) with the epics.md original
+> in parentheses where it aids traceability.
+>
+> 🧭 **Sequencing rationale — Drift Engine (2.3) before Reporting Agent (2.4).** This is a PRD pipeline
+> dependency, not a numbering artifact. architecture.md's pipeline data-flow places the drift stage
+> (`drift_engine.py … [Phase 2, optional]`) *inside* the sequence the Reporting Agent orchestrates
+> (DQA → **Drift** → Insights → Narrative → Render), and epics.md's Reporting Agent AC hard-depends on
+> it: "if a baseline profile exists for this dataset, the Drift Engine is included in the pipeline and
+> the report contains a Drift Analysis section." The Reporting Agent (2.4) cannot be implemented or
+> tested against its ACs until `DriftEngine` exists — so Drift Engine ships first.
+>
+> ⚠️ **Scope clarification — read before coding.** There are two *different* threshold concepts in this
+> codebase; do not conflate them:
+> - `PipelineConfig.metric_thresholds` (`backend/models/pipeline_config.py`, Story 2.1) — **user-configurable**
+>   per-metric fractional thresholds (e.g. `revenue: 0.15`), consumed by the **Monitoring Agent (2.5)**
+>   for period-over-period alert rules.
+> - The Drift Engine's HIGH/MEDIUM/LOW severity bands (mean shift >30%/>15%/>5%, etc.) are **fixed
+>   constants defined in architecture.md** (table below), per epics.md AC: "classified by severity …
+>   using the thresholds defined in the Architecture document." They are **not** read from
+>   `config.yaml` and the Drift Engine must **not** import `PipelineConfig`.
+
+## Story
+
+As a developer,
+I want a stateless computation module that compares a current DataFrame against a baseline profile and detects distributional drift across 7 checks,
+so that the Reporting Agent can include drift analysis in reports and the Monitoring Agent can trigger drift-based alerts.
+
+## Acceptance Criteria
+
+1. **Core computation.** Given a current DataFrame and an existing `BaselineProfile` (Pydantic model
+   with per-column mean, median, std, quartiles, null%, categorical distributions, schema fingerprint),
+   when `DriftEngine.compute_drift(current_df, baseline_profile)` is called, then the engine runs 7
+   detection checks — mean shift, median shift, variance shift, volume drift, categorical PSI
+   (Population Stability Index), new/missing categories, and schema drift — each finding is classified
+   HIGH/MEDIUM/LOW using the fixed thresholds in architecture.md (table in Dev Notes), and the return
+   type is a Pydantic-validated `DriftReport` with sections: `volume_drift`, `numeric_drift`,
+   `categorical_drift`, `schema_drift`, `drift_summary`, `overall_severity`, `recommendations`.
+
+2. **First-run baseline creation.** Given a dataset being analyzed for the first time (no baseline
+   exists), when the Drift Engine is invoked, then a `BaselineProfile` is computed from the current
+   DataFrame and saved as a JSON file in `backend/baselines/`, drift computation is skipped (no
+   comparison possible, no `DriftReport` produced), and a structlog entry is emitted with
+   `event="baseline_created"`.
+
+3. **Auto-rotation after 4 clean runs.** Given 4 consecutive pipeline runs with no HIGH-severity drift
+   findings, when the 4th clean run completes, then the current DataFrame's profile replaces the
+   existing baseline (auto-rotation), `consecutive_clean_runs` resets to 0, and a structlog entry is
+   emitted with `event="baseline_rotated"`.
+
+4. **Counter reset on HIGH finding.** Given a HIGH-severity drift finding in any run, when the finding
+   is detected, then `consecutive_clean_runs` resets to 0 and the existing baseline is retained
+   (unchanged on disk except for the counter reset).
+
+5. **Stateless, side-effect-scoped, observable.** Given any drift computation, when it completes, then
+   the `DriftReport` is Pydantic-validated before return; the Drift Engine has no side effects beyond
+   baseline file I/O (it does not send alerts, halt the pipeline, or run on a schedule); structlog
+   entries include `pipeline_run_id`, `stage="drift_engine"`, columns checked, and findings count; and
+   `backend/tests/test_drift_engine.py` passes with tests covering: each of the 7 checks in isolation,
+   first-run baseline creation, baseline auto-rotation after 4 clean runs, rotation counter reset on a
+   HIGH finding, and schema drift detection.
+
+## Tasks / Subtasks
+
+- [ ] **Task 0 — Verify assumptions against the current tree before writing any code** (all ACs)
+  - [ ] Confirm these files do **not** yet exist: `backend/models/drift_report.py`,
+        `backend/pipeline/drift_engine.py`. Confirm `backend/baselines/` exists but is empty (only
+        `.gitkeep`).
+  - [ ] Confirm `backend/models/pipeline_result.py:31-32` already has a `TYPE_CHECKING`-guarded forward
+        reference `from backend.models.drift_report import DriftReport` and a
+        `drift_report: "DriftReport | None" = None` field — your new module's class name and path
+        **must** match this exactly (`DriftReport` in `backend.models.drift_report`), or the forward
+        reference stays broken.
+  - [ ] Confirm `backend/errors/exceptions.py:92-97` already defines `DriftComputationError(PipelineStageError)`
+        — reuse it; do not create a new exception class.
+  - [ ] Confirm `backend/models/quality_report.py:16-22` already defines a `Severity(str, Enum)` with
+        `CRITICAL/HIGH/MEDIUM/LOW`. Reuse this enum for drift severity (do not define a parallel
+        `DriftSeverity` enum) — the Drift Engine only ever produces `HIGH`/`MEDIUM`/`LOW` (never
+        `CRITICAL`; drift is informational, never a halt condition).
+  - [ ] Confirm `backend/pipeline/insight_engine.py`'s `generate_insights()` does **not** currently
+        accept a drift parameter, and `backend/pipeline/orchestrator.py`'s `run_full_pipeline()` does
+        **not** currently call a drift stage. **Both are out of scope for this story** — wiring
+        `drift_engine.py` into the orchestrator/insight-engine data flow is the Reporting Agent's job
+        (filed 2.4; epics.md Story 2.3), per architecture.md's data-flow diagram which marks the drift
+        stage `[Phase 2, optional]` and the Reporting Agent AC ("Reporting Agent … invokes the pipeline
+        orchestrator … if a baseline
+        profile exists … the Drift Engine is included in the pipeline"). This story delivers the
+        `DriftEngine` class and its models only.
+  - [ ] Confirm `scipy` is present in `backend/requirements.txt` but **absent** from `pyproject.toml`
+        `dependencies` (same pre-existing pyproject/requirements.txt drift pattern Story 2.1 partially
+        reconciled for other deps — see Dev Notes).
+
+- [ ] **Task 1 — Define Pydantic models** `backend/models/drift_report.py` (AC: 1, 2)
+  - [ ] `ColumnBaselineStats(BaseModel)` — per-column statistical snapshot: `dtype: str`,
+        `null_pct: float`, and for numeric columns `mean: float | None`, `median: float | None`,
+        `std: float | None`, `q25: float | None`, `q75: float | None`; for categorical/object columns
+        `category_distribution: dict[str, float] | None` (value → proportion of non-null rows, sums to
+        ~1.0).
+  - [ ] `BaselineProfile(BaseModel)` — `dataset_key: str`, `row_count: int`,
+        `columns: dict[str, ColumnBaselineStats]`, `consecutive_clean_runs: int = 0`,
+        `created_at: str` (ISO 8601 UTC), `updated_at: str` (ISO 8601 UTC).
+  - [ ] `DriftFinding(BaseModel)` — one classified observation: `check: str` (e.g. `"mean_shift"`),
+        `column: str | None` (None for dataset-level checks like volume/schema drift),
+        `severity: Severity` (reused from `quality_report.py` — HIGH/MEDIUM/LOW only, never CRITICAL),
+        `actual_value: float`, `detail: str`.
+  - [ ] `VolumeDrift(BaseModel)` — `current_row_count: int`, `baseline_row_count: int`,
+        `pct_change: float`, `finding: DriftFinding | None` (None if below LOW threshold).
+  - [ ] `NumericColumnDrift(BaseModel)` — `column: str`, `mean_shift: DriftFinding | None`,
+        `median_shift: DriftFinding | None`, `variance_shift: DriftFinding | None`.
+  - [ ] `CategoricalColumnDrift(BaseModel)` — `column: str`, `psi: DriftFinding | None`,
+        `new_categories: list[str]`, `missing_categories: list[str]`,
+        `category_findings: list[DriftFinding]` (new/missing-category findings, if any crossed a
+        threshold).
+  - [ ] `SchemaDrift(BaseModel)` — `columns_added: list[str]`, `columns_removed: list[str]`,
+        `dtype_changes: dict[str, str]` (column → `"was X, now Y"`), `finding: DriftFinding | None`
+        (always HIGH if `columns_added`/`columns_removed`/`dtype_changes` is non-empty, per
+        architecture's "Always HIGH" rule).
+  - [ ] `DriftReport(BaseModel)` — `pipeline_run_id: str`, `computed_at: str` (ISO 8601 UTC),
+        `volume_drift: VolumeDrift`, `numeric_drift: list[NumericColumnDrift]`,
+        `categorical_drift: list[CategoricalColumnDrift]`, `schema_drift: SchemaDrift`,
+        `drift_summary: str` (one-line human-readable rollup), `overall_severity: Severity` (max
+        severity across all findings; `LOW` if none), `recommendations: list[str]`.
+  - [ ] Match existing Pydantic style (`backend/models/quality_report.py`,
+        `backend/models/insight_payload.py`): `from __future__ import annotations`, module docstring,
+        PascalCase noun models, snake_case fields, `X | None = None` optionals.
+
+- [ ] **Task 2 — Baseline persistence** `backend/pipeline/drift_engine.py` (AC: 2, 3, 4)
+  - [ ] `DriftEngine.__init__(self, baseline_dir: str | Path = "backend/baselines")` — accept an
+        override so tests can point at `tmp_path` instead of the real repo-root `backend/baselines/`.
+  - [ ] `_baseline_path(dataset_key: str) -> Path` → `{baseline_dir}/{dataset_key}.json`. `dataset_key`
+        is an opaque caller-supplied string (e.g. a sanitized filename stem) — **do not** derive it from
+        a file path inside this module; that derivation belongs to the caller (Reporting Agent, 2.4).
+  - [ ] `_load_baseline(dataset_key) -> BaselineProfile | None` — return `None` if the file doesn't
+        exist (first-run case). If the file exists but fails JSON parse or Pydantic validation, raise
+        `DriftComputationError` (corrupt baseline is an infrastructure failure per
+        `errors/exceptions.py:92-97`'s own docstring example — "baseline file corrupt").
+  - [ ] `_build_profile(df: pd.DataFrame, dataset_key: str, *, consecutive_clean_runs: int = 0) -> BaselineProfile`
+        — compute the per-column stats (numeric: mean/median/std/q25/q75/null_pct; categorical:
+        value_counts normalized to proportions/null_pct) and `row_count`.
+  - [ ] `_save_baseline(dataset_key, profile: BaselineProfile) -> None` — write pretty-printed JSON
+        (`model_dump_json(indent=2)` or equivalent) to `_baseline_path(dataset_key)`, creating
+        `baseline_dir` if it doesn't exist.
+
+- [ ] **Task 3 — Stateless drift computation** `DriftEngine.compute_drift` (AC: 1, 5)
+  - [ ] Pure function of `(current_df, baseline_profile) -> DriftReport` — **no file I/O, no baseline
+        mutation inside this method.** Raise `DriftComputationError` if `current_df` is empty or a
+        stats computation degenerates (e.g. `baseline_std == 0` making variance-shift ratio undefined —
+        treat as a defined edge case, not a silent `inf`/`NaN` in the output).
+  - [ ] Implement the 7 checks per architecture.md's table (reproduced below) — apply each threshold to
+        the **absolute value** of the relative change for mean/median shift (drift can go either
+        direction):
+
+        | Check | Formula | HIGH | MEDIUM | LOW |
+        |-------|---------|------|--------|-----|
+        | Mean shift | `abs((curr_mean - base_mean) / base_mean)` | >30% | >15% | >5% |
+        | Median shift | Same formula on medians | >30% | >15% | >5% |
+        | Variance shift | `curr_std / base_std` | >2.0 or <0.5 | >1.5 or <0.67 | — |
+        | Volume drift | `abs((len(curr) - len(base)) / len(base))` | >50% | >20% | >10% |
+        | Categorical PSI | `Σ (curr% - base%) × ln(curr% / base%)` | >0.25 | 0.10–0.25 | <0.10 |
+        | New/missing categories | Set comparison + representation % | Missing >10% repr | New >5% repr | — |
+        | Schema drift | Column set + dtype comparison | Always HIGH | — | — |
+
+  - [ ] **PSI edge case:** categories present in only one of curr/base produce `curr% = 0` or
+        `base% = 0`, which breaks `ln(0)` / division-by-zero. Apply a small epsilon (e.g. `0.0001`) to
+        both proportions before the formula — standard PSI practice, not a novel design choice, so use
+        the same epsilon convention across all category pairs for reproducible test assertions.
+  - [ ] Numeric checks (mean/median/variance) run only on columns that are numeric in **both** baseline
+        and current and are not already flagged by schema drift as added/removed/dtype-changed.
+        Categorical checks (PSI, new/missing) run only on columns categorical in both. A column present
+        in one but not the other is a schema-drift concern only — do not also emit a numeric/categorical
+        finding for it.
+  - [ ] `overall_severity` = the highest severity present across `volume_drift`, all `numeric_drift`,
+        all `categorical_drift`, and `schema_drift` findings; `Severity.LOW` if nothing crossed any
+        threshold. (Never `CRITICAL` — see Task 0.)
+  - [ ] `recommendations`: 1 short actionable string per HIGH finding (e.g. `"Investigate revenue mean
+        shift (+32% vs baseline) before trusting this period's report"`) — keep it data-driven text
+        generation (string templates), **not** an LLM call. The Drift Engine never touches
+        `backend.core.llm_client`.
+  - [ ] Emit `structlog.get_logger().info("drift_computed", pipeline_run_id=..., stage="drift_engine",
+        columns_checked=<int>, findings_count=<int>, overall_severity=...)` on every `compute_drift`
+        call.
+
+- [ ] **Task 4 — Orchestrating entry point + rotation** `DriftEngine.run` (AC: 2, 3, 4, 5)
+  - [ ] `DriftEngine.run(self, current_df: pd.DataFrame, dataset_key: str, pipeline_run_id: str) -> DriftReport | None`
+        — the one method a future caller (Reporting Agent, 2.4) invokes:
+        1. `_load_baseline(dataset_key)`. If `None` (first run): build a fresh profile via
+           `_build_profile`, `_save_baseline`, log `event="baseline_created"` with `pipeline_run_id`
+           and `dataset_key`, **return `None`** (no `DriftReport` — nothing to compare against).
+        2. Otherwise: call `compute_drift(current_df, baseline)`.
+        3. If `overall_severity == Severity.HIGH`: reset `baseline.consecutive_clean_runs = 0`,
+           `_save_baseline` (counter change only, profile stats untouched), do **not** rotate.
+        4. Else (no HIGH finding): increment `baseline.consecutive_clean_runs`. If it reaches `4`:
+           rebuild the profile from `current_df` via `_build_profile(..., consecutive_clean_runs=0)`,
+           `_save_baseline`, log `event="baseline_rotated"` with `pipeline_run_id` and `dataset_key`
+           (counter reset to 0 as part of the new profile). Otherwise just `_save_baseline` the
+           incremented counter on the **existing** profile (no rotation yet).
+        5. Return the computed `DriftReport`.
+  - [ ] This is the only method that performs baseline file I/O outside of first-run creation — keep
+        `compute_drift` itself free of it (Task 3).
+
+- [ ] **Task 5 — Dependency reconciliation** `pyproject.toml` (Task 0 finding)
+  - [ ] Add `"scipy>=1.11"` to `pyproject.toml` `dependencies` (already present in
+        `backend/requirements.txt`; this closes the same kind of pre-existing drift Story 2.1 partially
+        reconciled — do not touch any other pre-existing pyproject/requirements.txt mismatches, out of
+        scope here same as it was for 2.1). Verify with:
+        `grep -in scipy pyproject.toml backend/requirements.txt`.
+  - [ ] Using `scipy.stats` is optional — the PSI/variance formulas above are simple enough for
+        `math`/`numpy` directly. Add the dependency regardless, since architecture.md §230 names it as
+        the Phase 2 addition "for PSI computation" and a future story may rely on it being declared.
+
+- [ ] **Task 6 — Tests** `backend/tests/test_drift_engine.py` (AC: all)
+  - [ ] Add net-new fixtures to `backend/tests/conftest.py` (additive only, per its own docstring rule —
+        do not mutate `clean_sales_df`/`dirty_sales_df`): a baseline-profile fixture built from
+        `clean_sales_df`, and a "drifted" DataFrame variant (e.g. `revenue` scaled up ~40% to force a
+        HIGH mean-shift) for exercising each severity band deterministically.
+  - [ ] Cover each of the 7 checks in isolation (construct minimal current-df/baseline pairs that
+        isolate exactly one check crossing a threshold at a time).
+  - [ ] Cover first-run baseline creation: no existing file at `tmp_path`-scoped `baseline_dir` →
+        `run()` returns `None`, a JSON file is written, `event="baseline_created"` fires (assert via
+        `structlog.testing.capture_logs()`, matching the pattern `test_config.py` established for
+        `config_loaded`).
+  - [ ] Cover auto-rotation: seed a baseline JSON with `consecutive_clean_runs=3`, run a clean current
+        df, assert the baseline file now reflects the **new** profile (built from the just-run current
+        df) with `consecutive_clean_runs=0`, and `event="baseline_rotated"` fires.
+  - [ ] Cover counter reset on HIGH finding: seed `consecutive_clean_runs=2`, run a heavily-drifted
+        current df (HIGH finding), assert the baseline file's **stats are unchanged** but
+        `consecutive_clean_runs` is back to `0`.
+  - [ ] Cover schema drift: current df with a column added/removed/dtype-changed vs. baseline → always
+        HIGH, and confirm numeric/categorical checks are skipped for the mismatched column(s) (Task 3).
+  - [ ] Cover the `DriftComputationError` path: corrupt baseline JSON on disk → `run()` raises
+        `DriftComputationError`, not a raw `json.JSONDecodeError`/`ValidationError`.
+  - [ ] Use `tmp_path` for every baseline file write — never touch the real repo-root
+        `backend/baselines/` in tests (same rule Story 2.1 enforced for `config.yaml`).
+  - [ ] Run `uv run pytest backend/tests/test_drift_engine.py -v`, then the full regression command
+        `uv run pytest backend/tests/ --ignore=backend/tests/test_parse_file.py` and confirm zero
+        regressions against the Story 2.1 baseline (133 passed, 1 pre-existing skip) plus your new
+        tests.
+
+## Dev Notes
+
+### Architecture compliance
+
+- **Layer:** `backend/pipeline/drift_engine.py` and `backend/models/drift_report.py` are both Business
+  Logic layer (`pipeline/`, `models/` per architecture.md:743-747). May import `errors/`, `models/`,
+  stdlib, pandas/numpy/scipy. Must **not** import from `api/`, `agents/`, `renderers/`, or any legacy
+  module (`advanced_pipeline.py`, `comprehensive_analytics.py`, `nlp_processor.py`, `analytics.py`,
+  `main.py`, `main_enhanced.py`, `dashboard_api.py`). Must **not** import `backend.pipeline.config` /
+  `PipelineConfig` — see the scope clarification banner at the top of this story.
+- **Stateless-with-scoped-I/O:** epics.md AC5 is explicit — "no side effects beyond baseline file I/O
+  — it does not send alerts, halt the pipeline, or run on a schedule." `compute_drift` itself must have
+  zero I/O (Task 3); all file I/O lives in `run`/`_load_baseline`/`_save_baseline` (Task 2/4).
+- **Result-vs-Exception split** (`backend/errors/exceptions.py` docstring): a HIGH drift finding is a
+  normal, expected outcome — it is carried on `DriftReport.overall_severity`, never raised as an
+  exception. `DriftComputationError` is reserved for infrastructure failures (corrupt baseline file,
+  degenerate stats) per its existing docstring.
+- **Pydantic for all pipeline I/O:** `DriftReport` and `BaselineProfile` are Pydantic `BaseModel`s
+  (not the `PipelineResult` dataclass exception — that exception is documented in
+  `backend/models/pipeline_result.py` and applies only to `PipelineResult` itself).
+
+### Existing code you are extending (verified against current tree, 2026-07-05)
+
+- `backend/models/pipeline_result.py:26-33,58-60` already has the `drift_report: "DriftReport | None"`
+  field wired up under `TYPE_CHECKING`, forward-referencing exactly
+  `backend.models.drift_report.DriftReport` — this story's Task 1 fulfills that forward reference. No
+  changes to `pipeline_result.py` are needed or in scope.
+- `backend/errors/exceptions.py:92-97` — `DriftComputationError(PipelineStageError)` already exists
+  with a docstring naming this exact use case. Reuse it; do not add a new exception.
+- `backend/models/quality_report.py:16-22` — `Severity(str, Enum)` with `CRITICAL/HIGH/MEDIUM/LOW`
+  already exists. Reuse it for `DriftFinding.severity` / `DriftReport.overall_severity` (never emit
+  `CRITICAL` from the Drift Engine).
+- `backend/pipeline/orchestrator.py` and `backend/pipeline/insight_engine.py` are **not** touched by
+  this story (Task 0) — their drift integration is the Reporting Agent's scope (filed 2.4), confirmed against
+  architecture.md's data-flow diagram (`drift_engine.py … [Phase 2, optional]`).
+- `backend/baselines/` already exists (empty, `.gitkeep` only) — this is where baseline JSON files land
+  (architecture.md:166, :617).
+- `backend/tests/conftest.py` already provides `clean_sales_df`/`dirty_sales_df`/`pipeline_run_id`
+  fixtures and a session-autouse `configure_logging()` fixture; extend it additively (its own docstring
+  rule) rather than duplicating fixtures in the new test file.
+
+### Baseline JSON shape (illustrative)
+
+```json
+{
+  "dataset_key": "sales_weekly",
+  "row_count": 500,
+  "columns": {
+    "revenue": {
+      "dtype": "float64",
+      "null_pct": 0.0,
+      "mean": 2500.0,
+      "median": 2400.0,
+      "std": 350.0,
+      "q25": 2100.0,
+      "q75": 2800.0,
+      "category_distribution": null
+    },
+    "region": {
+      "dtype": "object",
+      "null_pct": 0.0,
+      "mean": null,
+      "median": null,
+      "std": null,
+      "q25": null,
+      "q75": null,
+      "category_distribution": {"north": 0.25, "south": 0.25, "east": 0.25, "west": 0.25}
+    }
+  },
+  "consecutive_clean_runs": 2,
+  "created_at": "2026-06-01T00:00:00Z",
+  "updated_at": "2026-07-01T00:00:00Z"
+}
+```
+
+### Testing standards (project-context.md; conftest.py)
+
+- Tests live in `backend/tests/` (not co-located) — new file `backend/tests/test_drift_engine.py`
+  (mirror rule: tests `pipeline/drift_engine.py` + `models/drift_report.py`).
+- Use `structlog.testing.capture_logs()` to assert on `baseline_created`/`baseline_rotated`/
+  `drift_computed` events — same pattern `test_config.py` established for `config_loaded` (Story 2.1).
+- Regression baseline: Story 2.1 left the suite at 133 passed, 1 pre-existing skip (`test_parse_file.py`,
+  unrelated `anthropic`-missing skip). Run
+  `uv run pytest backend/tests/ --ignore=backend/tests/test_parse_file.py` and confirm zero regressions
+  plus your new `test_drift_engine.py` tests passing.
+- `uv` only — `uv run pytest ...`. No bare `pytest`, no `pip install`.
+
+### Project Structure Notes
+
+- New files: `backend/models/drift_report.py`, `backend/pipeline/drift_engine.py`,
+  `backend/tests/test_drift_engine.py`.
+- Modified: `backend/tests/conftest.py` (additive fixtures only), `pyproject.toml` (+`scipy`).
+- No variance from the architecture target tree — both new files appear in it verbatim
+  (architecture.md:149, :155, :589, :597).
+- `backend/baselines/` is the fixed storage root in production; tests must override via
+  `DriftEngine(baseline_dir=tmp_path)` and never touch the real directory.
+
+### Definition of Done (sprint-status.yaml, applies from Story 1.4 onward)
+
+- All acceptance criteria met; unit tests pass; zero regressions in `uv run pytest backend/tests/`.
+- Run `/security-review` and resolve all Critical/High findings before marking done. Pay attention to:
+  baseline JSON deserialization safety (use `json.loads` + Pydantic validation, never `eval`/`pickle`),
+  and that baseline files never capture PII beyond what the source CSV already contained (category
+  values are stored verbatim — flag if source columns could contain free-text PII, but no new PII
+  surface is introduced by this story beyond what Story 1.2's DQA already reads).
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 2.2: Drift Engine] (AC source, lines 436-472)
+- [Source: _bmad-output/planning-artifacts/architecture.md#L149,L155] (target file locations:
+  `pipeline/drift_engine.py`, `models/drift_report.py`)
+- [Source: _bmad-output/planning-artifacts/architecture.md#L189,L198-L199,L201-L223] (Drift Engine
+  specification, 7-check threshold table, integration notes, explicit non-goals)
+- [Source: _bmad-output/planning-artifacts/architecture.md#L230] (scipy.stats — Phase 2 new dependency)
+- [Source: _bmad-output/planning-artifacts/architecture.md#L433,L486-L506] (compute_drift signature;
+  Result-vs-Exception dual strategy)
+- [Source: _bmad-output/planning-artifacts/architecture.md#L743-L747,L754-L764] (three-layer boundaries;
+  pipeline data-flow diagram — drift stage marked Phase 2/optional, wired by the Reporting Agent, filed 2.4)
+- [Source: _bmad-output/planning-artifacts/architecture.md#L875] (consecutive_clean_runs rotation
+  counter — gap-analysis resolution)
+- [Source: backend/models/pipeline_result.py#L26-L33,L58-L60] (existing forward reference this story
+  fulfills)
+- [Source: backend/errors/exceptions.py#L92-L97] (DriftComputationError — reuse, do not recreate)
+- [Source: backend/models/quality_report.py#L16-L22] (Severity enum — reuse for drift severity)
+- [Source: backend/tests/conftest.py] (existing fixtures to extend additively)
+- [Source: _bmad-output/implementation-artifacts/2-1-configuration-layer.md] (previous Epic 2 story —
+  established the pyproject.toml/requirements.txt reconciliation pattern this story follows for scipy,
+  and the tmp_path-only file-write testing discipline)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -42,7 +42,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-14
-last_updated: 2026-07-02  # updated: story 2-2-llm-client-abstraction created (ready-for-dev); inserted between 2.1 and original 2.2
+last_updated: 2026-07-05  # updated: story 2-2-llm-client-abstraction + corrective 2-2b-harden-llm-client-multi-caller-use both done
 project: SavvyCortex
 project_key: NOKEY
 tracking_system: file-system
@@ -85,7 +85,8 @@ development_status:
   # Epic 2: Automated Reporting & Data Monitoring
   epic-2: in-progress
   2-1-configuration-layer: ready-for-dev
-  2-2-llm-client-abstraction: ready-for-dev  # inserted 2026-07-02: prerequisite for 2.3 and 2.4 LLM calls
+  2-2-llm-client-abstraction: done  # inserted 2026-07-02: prerequisite for 2.3 and 2.4 LLM calls; implemented + reviewed 2026-07-05
+  2-2b-harden-llm-client-multi-caller-use: done  # corrective story from 2-2 code review; implemented + re-reviewed (0 findings) 2026-07-05
   2-2-drift-engine: backlog
   2-3-reporting-agent: backlog
   2-4-monitoring-agent-alert-delivery: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -42,7 +42,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-14
-last_updated: 2026-07-05  # updated: story 2-1-configuration-layer done; 2-2-llm-client-abstraction + corrective 2-2b-harden-llm-client-multi-caller-use both done
+last_updated: 2026-07-05  # updated: story 2-1-configuration-layer done; 2-2-llm-client-abstraction + corrective 2-2b-harden-llm-client-multi-caller-use both done; Epic 2 renumbered (drift→2.3, reporting→2.4, monitoring→2.5); 2-3-drift-engine created (ready-for-dev)
 project: SavvyCortex
 project_key: NOKEY
 tracking_system: file-system
@@ -85,11 +85,15 @@ development_status:
   # Epic 2: Automated Reporting & Data Monitoring
   epic-2: in-progress
   2-1-configuration-layer: done  # implemented + reviewed (1 fix applied: mapping-vs-list silent-swallow bug) 2026-07-05
-  2-2-llm-client-abstraction: done  # inserted 2026-07-02: prerequisite for 2.3 and 2.4 LLM calls; implemented + reviewed 2026-07-05
+  2-2-llm-client-abstraction: done  # inserted 2026-07-02: prerequisite for the Reporting (2.4) and Monitoring (2.5) agents' LLM calls; implemented + reviewed 2026-07-05
   2-2b-harden-llm-client-multi-caller-use: done  # corrective story from 2-2 code review; implemented + re-reviewed (0 findings) 2026-07-05
-  2-2-drift-engine: backlog
-  2-3-reporting-agent: backlog
-  2-4-monitoring-agent-alert-delivery: backlog
+  # Numbering reconciliation (2026-07-05): epics.md Epic 2 sequence diverged from filed history because
+  # 2-2-llm-client-abstraction (+2-2b) was filed out-of-band and took the 2.2 slot. Drift Engine
+  # (epics.md 2.2) renumbered → 2.3; Reporting Agent (epics.md 2.3) → 2.4; Monitoring Agent (epics.md
+  # 2.4) → 2.5. See _bmad-output/implementation-artifacts/2-3-drift-engine.md header for the full map.
+  2-3-drift-engine: ready-for-dev  # created 2026-07-05 (was 2-2-drift-engine; renumbered per reconciliation above)
+  2-4-reporting-agent: backlog  # was 2-3-reporting-agent
+  2-5-monitoring-agent-alert-delivery: backlog  # was 2-4-monitoring-agent-alert-delivery
   epic-2-retrospective: optional
 
   # Epic 3: Web Application & Customer Dashboard

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -42,7 +42,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-14
-last_updated: 2026-07-05  # updated: story 2-2-llm-client-abstraction + corrective 2-2b-harden-llm-client-multi-caller-use both done
+last_updated: 2026-07-05  # updated: story 2-1-configuration-layer done; 2-2-llm-client-abstraction + corrective 2-2b-harden-llm-client-multi-caller-use both done
 project: SavvyCortex
 project_key: NOKEY
 tracking_system: file-system
@@ -84,7 +84,7 @@ development_status:
 
   # Epic 2: Automated Reporting & Data Monitoring
   epic-2: in-progress
-  2-1-configuration-layer: ready-for-dev
+  2-1-configuration-layer: done  # implemented + reviewed (1 fix applied: mapping-vs-list silent-swallow bug) 2026-07-05
   2-2-llm-client-abstraction: done  # inserted 2026-07-02: prerequisite for 2.3 and 2.4 LLM calls; implemented + reviewed 2026-07-05
   2-2b-harden-llm-client-multi-caller-use: done  # corrective story from 2-2 code review; implemented + re-reviewed (0 findings) 2026-07-05
   2-2-drift-engine: backlog

--- a/backend/core/__init__.py
+++ b/backend/core/__init__.py
@@ -1,0 +1,1 @@
+# backend/core — shared utilities (LLM client, future: cost tracking)

--- a/backend/core/llm_client.py
+++ b/backend/core/llm_client.py
@@ -30,9 +30,9 @@ from typing import Any
 
 import structlog
 
+from backend.core.logging import ensure_logging_configured, scoped_pipeline_run_id
 from backend.errors.exceptions import LLMProviderError
 from backend.models.insight_report import InsightReport, NarrativeContent
-from backend.pipeline.config import bind_pipeline_run_id
 
 _BACKOFF_DELAYS = [1, 2, 4]
 _MAX_ATTEMPTS = 3
@@ -85,76 +85,82 @@ class LLMClient:
         up to 3 retry attempts with exponential backoff. If all providers
         fail, returns a fallback InsightReport.
 
-        Binds ``pipeline_run_id`` to the logging context so direct callers
-        (future agents) get run-tagged logs without a separate step.
+        Binds ``pipeline_run_id`` to the logging context for the duration of this
+        call so direct callers (future agents) get run-tagged logs without a
+        separate step; the binding is restored to whatever was ambient before the
+        call once this method returns, so it never leaks into unrelated log lines
+        on a reused thread/asyncio task. Also guarantees JSON log output even if
+        the caller never called ``configure_logging()`` itself, without disturbing
+        a caller/test that already configured structlog.
         """
-        bind_pipeline_run_id(pipeline_run_id)
+        ensure_logging_configured()
 
-        providers: list[tuple[str, Any]] = [
-            ("claude", self._call_claude),
-            ("openai", self._call_openai),
-            ("gemini", self._call_gemini),
-        ]
+        with scoped_pipeline_run_id(pipeline_run_id):
+            providers: list[tuple[str, Any]] = [
+                ("claude", self._call_claude),
+                ("openai", self._call_openai),
+                ("gemini", self._call_gemini),
+            ]
 
-        consecutive_failures = 0
-        providers_tried: list[str] = []
+            consecutive_failures = 0
+            providers_tried: list[str] = []
 
-        for i, (provider_name, call_fn) in enumerate(providers):
-            if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
-                break
-
-            providers_tried.append(provider_name)
-
-            try:
-                report = self._try_provider(
-                    provider_name, call_fn, payload_json,
-                )
-                self._logger.info(
-                    "narrative_generated",
-                    provider=provider_name,
-                    model=report.metadata.get("model", "unknown"),
-                    token_count=report.metadata.get("token_count", 0),
-                    duration_ms=report.metadata.get("duration_ms", 0),
-                )
-                return report
-
-            except LLMProviderError:
-                raise
-
-            except Exception:
-                consecutive_failures += 1
-
+            for i, (provider_name, call_fn) in enumerate(providers):
                 if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
                     break
 
-                if i + 1 < len(providers):
-                    next_provider = providers[i + 1][0]
-                    self._logger.warning(
-                        "llm_fallback",
-                        from_provider=provider_name,
-                        to_provider=next_provider,
-                        reason="all_attempts_exhausted",
-                    )
+                providers_tried.append(provider_name)
 
-        self._logger.error(
-            "llm_circuit_breaker",
-            consecutive_failures=consecutive_failures,
-            providers_tried=providers_tried,
-        )
-        return InsightReport(
-            executive_summary="",
-            key_findings=[],
-            metadata={
-                "provider": "none",
-                "fallback": True,
-                "providers_tried": providers_tried,
-            },
-            fallback=True,
-            fallback_reason=(
-                f"All LLM providers failed after {consecutive_failures} "
-                "consecutive failures"
-            ),
-        )
+                try:
+                    report = self._try_provider(
+                        provider_name, call_fn, payload_json,
+                    )
+                    self._logger.info(
+                        "narrative_generated",
+                        provider=provider_name,
+                        model=report.metadata.get("model", "unknown"),
+                        token_count=report.metadata.get("token_count", 0),
+                        duration_ms=report.metadata.get("duration_ms", 0),
+                    )
+                    return report
+
+                except LLMProviderError:
+                    raise
+
+                except Exception:
+                    consecutive_failures += 1
+
+                    if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                        break
+
+                    if i + 1 < len(providers):
+                        next_provider = providers[i + 1][0]
+                        self._logger.warning(
+                            "llm_fallback",
+                            from_provider=provider_name,
+                            to_provider=next_provider,
+                            reason="all_attempts_exhausted",
+                        )
+
+            self._logger.error(
+                "llm_circuit_breaker",
+                consecutive_failures=consecutive_failures,
+                providers_tried=providers_tried,
+            )
+            return InsightReport(
+                executive_summary="",
+                key_findings=[],
+                metadata={
+                    "provider": "none",
+                    "fallback": True,
+                    "providers_tried": providers_tried,
+                },
+                fallback=True,
+                fallback_reason=(
+                    f"All LLM providers failed after {consecutive_failures} "
+                    "consecutive failures"
+                ),
+            )
 
     def _try_provider(
         self,

--- a/backend/core/llm_client.py
+++ b/backend/core/llm_client.py
@@ -1,0 +1,302 @@
+"""LLMClient — shared LLM narrative client with provider resilience.
+
+Extracted from ``backend/pipeline/narrative_generator.py`` in Story 2.2 so the
+Reporting Agent (2.3) and Monitoring Agent (2.4) can invoke LLM calls without
+duplicating the retry/fallback/circuit-breaker machinery. This is an internal
+code-reuse extraction, NOT a framework abstraction — provider SDK imports
+(``anthropic``, ``openai``, ``google.genai``) remain lazy imports inside their
+respective ``_call_*`` methods (architecture.md §289: no LangChain, no
+abstraction layers).
+
+Transforms a serialized :class:`InsightPayload` (deterministic statistics from
+the Insight Engine) into an :class:`InsightReport` (structured prose) using
+Claude Structured Outputs.
+
+Resilience layers (architecture.md §525-529):
+
+1. **Retry** — 3 attempts per provider, exponential backoff (1s, 2s, 4s).
+2. **Fallback** — Claude → OpenAI → Gemini.
+3. **Circuit breaker** — 3 consecutive provider-level failures → skip
+   narrative, return a fallback InsightReport so the pipeline continues.
+4. **4xx guard** — client errors are never retried (they indicate a code
+   bug, not a transient failure).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import structlog
+
+from backend.errors.exceptions import LLMProviderError
+from backend.models.insight_report import InsightReport, NarrativeContent
+from backend.pipeline.config import bind_pipeline_run_id
+
+_BACKOFF_DELAYS = [1, 2, 4]
+_MAX_ATTEMPTS = 3
+_CIRCUIT_BREAKER_THRESHOLD = 3
+
+# Provider model identifiers. Keep these current — retired snapshots return
+# 404 at call time, which the retry/fallback machinery masks as a transient
+# failure. ``claude-sonnet-4-6`` is the current Sonnet (the older
+# ``claude-sonnet-4-20250514`` snapshot retired 2026-06-15).
+_CLAUDE_MODEL = "claude-sonnet-4-6"
+_OPENAI_MODEL = "gpt-4o"
+_GEMINI_MODEL = "gemini-2.0-flash"
+
+_SYSTEM_PROMPT = (
+    "You are a data analyst writing a professional narrative report. "
+    "You will receive a JSON payload of pre-computed statistics. "
+    "Your job is to NARRATE these statistics into clear, professional prose. "
+    "CRITICAL RULES:\n"
+    "- Reference ONLY numbers that appear in the provided data.\n"
+    "- Do NOT independently compute, invent, or hallucinate any numerical values.\n"
+    "- Do NOT perform any arithmetic on the provided numbers.\n"
+    "- Write in third person, professional tone.\n"
+    "- Structure your response with these fields: executive_summary, "
+    "key_findings (list of titled sections), anomaly_analysis (if anomalies exist), "
+    "and recommendations_narrative (if recommendations exist)."
+)
+
+
+class LLMClient:
+    """Generates narrative prose from computed statistics via LLM.
+
+    Instantiate per consumer (``NarrativeGenerator``, and future agents) —
+    this mirrors how the orchestrator instantiates each pipeline stage, and
+    keeps no cross-caller state.
+    """
+
+    def __init__(self) -> None:
+        # Keep ``stage="narrative_generator"`` — monitoring/alerting reads this
+        # key off the JSON log stream; changing it would break AC6.
+        self._logger = structlog.get_logger().bind(stage="narrative_generator")
+
+    def generate_narrative(
+        self,
+        payload_json: str,
+        pipeline_run_id: str,
+    ) -> InsightReport:
+        """Transform a serialized InsightPayload into a narrated InsightReport.
+
+        Tries Claude first, then OpenAI, then Gemini. Each provider gets
+        up to 3 retry attempts with exponential backoff. If all providers
+        fail, returns a fallback InsightReport.
+
+        Binds ``pipeline_run_id`` to the logging context so direct callers
+        (future agents) get run-tagged logs without a separate step.
+        """
+        bind_pipeline_run_id(pipeline_run_id)
+
+        providers: list[tuple[str, Any]] = [
+            ("claude", self._call_claude),
+            ("openai", self._call_openai),
+            ("gemini", self._call_gemini),
+        ]
+
+        consecutive_failures = 0
+        providers_tried: list[str] = []
+
+        for i, (provider_name, call_fn) in enumerate(providers):
+            if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                break
+
+            providers_tried.append(provider_name)
+
+            try:
+                report = self._try_provider(
+                    provider_name, call_fn, payload_json,
+                )
+                self._logger.info(
+                    "narrative_generated",
+                    provider=provider_name,
+                    model=report.metadata.get("model", "unknown"),
+                    token_count=report.metadata.get("token_count", 0),
+                    duration_ms=report.metadata.get("duration_ms", 0),
+                )
+                return report
+
+            except LLMProviderError:
+                raise
+
+            except Exception:
+                consecutive_failures += 1
+
+                if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                    break
+
+                if i + 1 < len(providers):
+                    next_provider = providers[i + 1][0]
+                    self._logger.warning(
+                        "llm_fallback",
+                        from_provider=provider_name,
+                        to_provider=next_provider,
+                        reason="all_attempts_exhausted",
+                    )
+
+        self._logger.error(
+            "llm_circuit_breaker",
+            consecutive_failures=consecutive_failures,
+            providers_tried=providers_tried,
+        )
+        return InsightReport(
+            executive_summary="",
+            key_findings=[],
+            metadata={
+                "provider": "none",
+                "fallback": True,
+                "providers_tried": providers_tried,
+            },
+            fallback=True,
+            fallback_reason=(
+                f"All LLM providers failed after {consecutive_failures} "
+                "consecutive failures"
+            ),
+        )
+
+    def _try_provider(
+        self,
+        provider_name: str,
+        call_fn: Any,
+        payload_json: str,
+    ) -> InsightReport:
+        """Attempt up to ``_MAX_ATTEMPTS`` calls to a single provider."""
+        last_exc: Exception | None = None
+
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            try:
+                start = time.perf_counter()
+                report = call_fn(payload_json)
+                duration_ms = int((time.perf_counter() - start) * 1000)
+                report.metadata["duration_ms"] = duration_ms
+                return report
+
+            except Exception as exc:
+                if self._is_client_error(exc):
+                    self._logger.error(
+                        "llm_client_error",
+                        provider=provider_name,
+                        status_code=getattr(exc, "status_code", None),
+                        error=str(exc),
+                    )
+                    raise LLMProviderError(
+                        f"Client error from {provider_name}",
+                        provider=provider_name,
+                        cause=exc,
+                    ) from exc
+
+                last_exc = exc
+                self._logger.warning(
+                    "llm_retry",
+                    provider=provider_name,
+                    attempt=attempt,
+                    error_type=type(exc).__name__,
+                    backoff_seconds=_BACKOFF_DELAYS[attempt - 1] if attempt <= len(_BACKOFF_DELAYS) else _BACKOFF_DELAYS[-1],
+                )
+
+                if attempt < _MAX_ATTEMPTS:
+                    time.sleep(_BACKOFF_DELAYS[attempt - 1])
+
+        raise last_exc  # type: ignore[misc]
+
+    def _is_client_error(self, exc: Exception) -> bool:
+        status = getattr(exc, "status_code", None)
+        if status is not None and 400 <= status < 500:
+            return True
+        return False
+
+    def _build_report(
+        self,
+        content: NarrativeContent,
+        *,
+        provider: str,
+        model: str,
+        token_count: int,
+    ) -> InsightReport:
+        """Compose the renderer-facing InsightReport from LLM narrative + telemetry.
+
+        ``metadata`` and ``fallback`` are set here (by code), never by the
+        model — the model only ever sees the :class:`NarrativeContent` schema.
+        """
+        return InsightReport(
+            **content.model_dump(),
+            metadata={
+                "provider": provider,
+                "model": model,
+                "token_count": token_count,
+            },
+            fallback=False,
+        )
+
+    def _build_prompt(self, payload_json: str) -> str:
+        return (
+            f"{_SYSTEM_PROMPT}\n\n"
+            f"Here is the computed data payload:\n{payload_json}"
+        )
+
+    def _call_claude(self, payload_json: str) -> InsightReport:
+        import anthropic
+
+        # max_retries=0 — this class implements its own retry/backoff loop; the
+        # SDK's default of 2 internal retries would compound with it.
+        client = anthropic.Anthropic(
+            api_key=os.environ.get("ANTHROPIC_API_KEY"), max_retries=0
+        )
+        result = client.messages.parse(
+            model=_CLAUDE_MODEL,
+            max_tokens=4096,
+            messages=[{"role": "user", "content": self._build_prompt(payload_json)}],
+            output_format=NarrativeContent,
+        )
+        content: NarrativeContent = result.parsed_output  # type: ignore[assignment]
+        token_count = getattr(result.usage, "output_tokens", 0) + getattr(
+            result.usage, "input_tokens", 0
+        )
+        return self._build_report(
+            content, provider="claude", model=_CLAUDE_MODEL, token_count=token_count
+        )
+
+    def _call_openai(self, payload_json: str) -> InsightReport:
+        import openai
+
+        client = openai.OpenAI(
+            api_key=os.environ.get("OPENAI_API_KEY"), max_retries=0
+        )
+        result = client.beta.chat.completions.parse(
+            model=_OPENAI_MODEL,
+            messages=[{"role": "user", "content": self._build_prompt(payload_json)}],
+            response_format=NarrativeContent,
+        )
+        content: NarrativeContent = result.choices[0].message.parsed  # type: ignore[assignment]
+        return self._build_report(
+            content,
+            provider="openai",
+            model=_OPENAI_MODEL,
+            token_count=getattr(result.usage, "total_tokens", 0),
+        )
+
+    def _call_gemini(self, payload_json: str) -> InsightReport:
+        import json
+
+        from google import genai
+
+        client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
+        result = client.models.generate_content(
+            model=_GEMINI_MODEL,
+            contents=self._build_prompt(payload_json),
+            config={
+                "response_mime_type": "application/json",
+                "response_schema": NarrativeContent,
+            },
+        )
+        content = NarrativeContent.model_validate(json.loads(result.text))
+        return self._build_report(
+            content,
+            provider="gemini",
+            model=_GEMINI_MODEL,
+            token_count=getattr(
+                getattr(result, "usage_metadata", None), "total_token_count", 0
+            ),
+        )

--- a/backend/core/logging.py
+++ b/backend/core/logging.py
@@ -1,0 +1,88 @@
+"""Shared logging / context-binding primitives — Story 2.2b.
+
+Moved out of ``backend/pipeline/config.py`` so that neither ``pipeline/`` nor
+``agents/`` (Reporting Agent 2.3, Monitoring Agent 2.4) has to import the other's
+package for structured logging setup. Both layers depend on ``backend/core/``;
+``backend/core/`` depends on neither.
+
+Logging discipline (enforced here):
+
+* All log output is JSON on stderr, one event per line.
+* Every event carries ``pipeline_run_id`` once :func:`bind_pipeline_run_id` (whole
+  run) or :func:`scoped_pipeline_run_id` (single call) has bound it — contextvars
+  propagate across threads and async tasks without threading the ID through every
+  call site.
+* Callers — CLI entrypoints, FastAPI startup, pytest session — MUST call
+  :func:`configure_logging` explicitly. This module never self-configures at import
+  time; that would make test isolation and library usage impossible.
+* :mod:`logging.basicConfig` is never called (architecture.md:542 anti-pattern —
+  the stdlib handler would compete with structlog and produce mixed plain-text /
+  JSON output).
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import structlog
+
+
+def configure_logging() -> None:
+    """Install the structlog processor chain for JSON output.
+
+    Idempotent — safe to call multiple times (for example, once from the CLI and
+    again from a pytest session-scoped fixture). Must be invoked before any
+    ``structlog.get_logger()`` call that expects JSON output.
+    """
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+
+
+def ensure_logging_configured() -> None:
+    """Configure JSON logging only if nothing has configured structlog yet.
+
+    Direct callers (future agents) that skip an explicit ``configure_logging()``
+    step still get JSON output. Callers that already configured structlog
+    themselves — including test fixtures that install a capture processor — are
+    left untouched, so this must never unconditionally call
+    :func:`configure_logging`.
+    """
+    if not structlog.is_configured():
+        configure_logging()
+
+
+def bind_pipeline_run_id(run_id: str) -> None:
+    """Bind ``pipeline_run_id=<run_id>`` to the current context, for the run's
+    full lifetime.
+
+    Every subsequent log event emitted on the same thread / asyncio task will
+    carry this key until it is explicitly cleared or the context ends. Intended
+    for whole-process-run callers (e.g. ``orchestrator.run_full_pipeline``) where
+    the binding should outlive any single stage. For a single scoped call, use
+    :func:`scoped_pipeline_run_id` instead.
+    """
+    structlog.contextvars.bind_contextvars(pipeline_run_id=run_id)
+
+
+@contextmanager
+def scoped_pipeline_run_id(run_id: str) -> Iterator[None]:
+    """Bind ``pipeline_run_id=<run_id>`` for the duration of the ``with`` block only.
+
+    Snapshots whatever contextvars state exists on entry and restores exactly
+    that snapshot on exit (success or exception) — a caller that already bound
+    ``pipeline_run_id`` (e.g. the orchestrator, for the whole pipeline run) gets
+    its own binding restored afterward rather than cleared. A caller with no
+    prior binding gets it removed afterward, so it never leaks into unrelated log
+    lines on a reused thread/asyncio task.
+    """
+    with structlog.contextvars.bound_contextvars(pipeline_run_id=run_id):
+        yield

--- a/backend/models/pipeline_config.py
+++ b/backend/models/pipeline_config.py
@@ -1,0 +1,257 @@
+"""Pipeline configuration Pydantic contract — Story 2.1.
+
+Defines the schema for the project's ``config.yaml`` (data sources, report
+schedule, metric thresholds, alert recipients, output settings) plus the SMTP
+secrets sourced from environment variables. :meth:`PipelineConfig.load` is the
+single entrypoint every agent/pipeline component uses to read configuration —
+``backend/pipeline/config.py`` re-exports :class:`PipelineConfig` so both
+import paths resolve to this module.
+
+Secrets discipline: SMTP credentials are sourced ONLY from environment
+variables (via ``.env`` / ``python-dotenv`` in dev), never from ``config.yaml``
+— :meth:`PipelineConfig.load` overwrites any ``smtp`` key present in the YAML
+with the environment-sourced values.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import croniter
+import structlog
+import yaml
+from pydantic import BaseModel, EmailStr, Field, ValidationError, field_validator, model_validator
+
+from backend.errors.exceptions import ConfigurationError
+
+DEFAULT_THRESHOLD = 0.15
+DEFAULT_CONFIG_PATH = Path("config.yaml")
+
+_VALID_INTERVALS = {"daily", "weekly", "monthly"}
+_VALID_FORMATS = {"docx", "pdf"}
+
+
+class ThresholdConfig(BaseModel):
+    """Per-metric fractional change thresholds; 0.15 == +-15%.
+
+    Accepts the flat ``{metric: threshold}`` mapping ``config.yaml`` uses for
+    ``metric_thresholds`` directly (wrapped into this model's single field).
+    """
+
+    thresholds: dict[str, float] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_bare_mapping(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "thresholds" not in data:
+            return {"thresholds": data}
+        return data
+
+    @field_validator("thresholds")
+    @classmethod
+    def _positive_thresholds(cls, value: dict[str, float]) -> dict[str, float]:
+        for metric, threshold in value.items():
+            if threshold <= 0:
+                raise ValueError(
+                    f"metric_thresholds.{metric} must be > 0, got {threshold}"
+                )
+        return value
+
+    def get(self, metric: str, default: float = DEFAULT_THRESHOLD) -> float:
+        """Return the configured threshold for ``metric``, or the default."""
+        return self.thresholds.get(metric, default)
+
+
+class ScheduleConfig(BaseModel):
+    """Report schedule — exactly one of a named interval or a cron expression."""
+
+    interval: str | None = None
+    cron: str | None = None
+
+    @field_validator("interval")
+    @classmethod
+    def _valid_interval(cls, value: str | None) -> str | None:
+        if value is not None and value not in _VALID_INTERVALS:
+            raise ValueError(
+                f"report_schedule.interval must be one of {sorted(_VALID_INTERVALS)}, "
+                f"got {value!r}"
+            )
+        return value
+
+    @field_validator("cron")
+    @classmethod
+    def _valid_cron(cls, value: str | None) -> str | None:
+        if value is not None and not croniter.croniter.is_valid(value):
+            raise ValueError(
+                f"report_schedule.cron is not a valid cron expression: {value!r}"
+            )
+        return value
+
+    @model_validator(mode="after")
+    def _exactly_one_of_interval_or_cron(self) -> ScheduleConfig:
+        if bool(self.interval) == bool(self.cron):
+            raise ValueError(
+                "report_schedule must set exactly one of 'interval' or 'cron'"
+            )
+        return self
+
+
+class DataSourceConfig(BaseModel):
+    """File paths or directories the agents pull data from.
+
+    Accepts the flat list ``config.yaml`` uses for ``data_sources`` directly
+    (wrapped into this model's single field).
+    """
+
+    paths: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_bare_list(cls, data: Any) -> Any:
+        if isinstance(data, list):
+            return {"paths": data}
+        if isinstance(data, dict) and data and "paths" not in data:
+            # Non-empty dict without the expected key means the caller passed
+            # a mapping where a list was expected (e.g. a YAML indentation
+            # mistake) — reject it. An empty dict is the default-construction
+            # path (default_factory=DataSourceConfig with no field present in
+            # the parent config) and must fall through unchanged.
+            raise ValueError(
+                f"data_sources must be a list of file paths, got a mapping: {data!r}"
+            )
+        return data
+
+    @field_validator("paths")
+    @classmethod
+    def _non_empty(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError("data_sources must be a non-empty list")
+        return value
+
+
+class OutputConfig(BaseModel):
+    """Rendered report output settings."""
+
+    format: str = "docx"
+    output_dir: str = "output/"
+
+    @field_validator("format")
+    @classmethod
+    def _valid_format(cls, value: str) -> str:
+        if value not in _VALID_FORMATS:
+            raise ValueError(
+                f"output.format must be one of {sorted(_VALID_FORMATS)}, got {value!r}"
+            )
+        return value
+
+
+class AlertConfig(BaseModel):
+    """Alert recipient list.
+
+    Accepts the flat list ``config.yaml`` uses for ``alert_recipients``
+    directly (wrapped into this model's single field). Email format is
+    validated by Pydantic's ``EmailStr``.
+    """
+
+    recipients: list[EmailStr] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _wrap_bare_list(cls, data: Any) -> Any:
+        if isinstance(data, list):
+            return {"recipients": data}
+        if isinstance(data, dict) and data and "recipients" not in data:
+            # Non-empty dict without the expected key means the caller passed
+            # a mapping where a list was expected (e.g. a YAML indentation
+            # mistake) — reject it. An empty dict is the default-construction
+            # path (default_factory=AlertConfig, field absent from the parent
+            # config) and must fall through unchanged.
+            raise ValueError(
+                f"alert_recipients must be a list of email addresses, got a mapping: {data!r}"
+            )
+        return data
+
+
+class SmtpSettings(BaseModel):
+    """SMTP credentials — sourced ONLY from environment variables.
+
+    Never populated from ``config.yaml``; see :meth:`PipelineConfig.load`.
+    """
+
+    host: str | None = None
+    port: int = 587
+    username: str | None = None
+    password: str | None = None
+    from_address: str | None = None
+
+
+class PipelineConfig(BaseModel):
+    """Root pipeline configuration — the typed contract for ``config.yaml``."""
+
+    data_sources: DataSourceConfig
+    report_schedule: ScheduleConfig
+    metric_thresholds: ThresholdConfig = Field(default_factory=ThresholdConfig)
+    alert_recipients: AlertConfig = Field(default_factory=AlertConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
+    smtp: SmtpSettings = Field(default_factory=SmtpSettings)
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> PipelineConfig:
+        """Load, validate, and return a typed :class:`PipelineConfig`.
+
+        Stateless — re-reads and re-validates ``path`` (default ``config.yaml``
+        at the project root) on every call, so a caller that invokes this again
+        after the file changes on disk gets the updated values (FR10 hot-reload;
+        no process restart or module reimport required). SMTP credentials are
+        always sourced from the environment, never from the YAML.
+        """
+        from dotenv import load_dotenv
+
+        load_dotenv()
+
+        config_path = Path(path) if path is not None else DEFAULT_CONFIG_PATH
+
+        try:
+            raw_text = config_path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise ConfigurationError(f"Config file not found: {config_path}") from exc
+
+        try:
+            raw_data = yaml.safe_load(raw_text) or {}
+        except yaml.YAMLError as exc:
+            raise ConfigurationError(
+                f"Config file is not valid YAML: {config_path}: {exc}"
+            ) from exc
+
+        try:
+            smtp_port = int(os.environ.get("SMTP_PORT", "587"))
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"SMTP_PORT environment variable must be an integer: {exc}"
+            ) from exc
+
+        raw_data["smtp"] = {
+            "host": os.environ.get("SMTP_HOST"),
+            "port": smtp_port,
+            "username": os.environ.get("SMTP_USERNAME"),
+            "password": os.environ.get("SMTP_PASSWORD"),
+            "from_address": os.environ.get("SMTP_FROM"),
+        }
+
+        try:
+            config = cls.model_validate(raw_data)
+        except ValidationError as exc:
+            raise ConfigurationError(
+                f"Invalid configuration in {config_path}: {exc}"
+            ) from exc
+
+        structlog.get_logger().info(
+            "config_loaded",
+            schedule=config.report_schedule.interval or config.report_schedule.cron,
+            threshold_keys=sorted(config.metric_thresholds.thresholds.keys()),
+            recipient_count=len(config.alert_recipients.recipients),
+            output_format=config.output.format,
+        )
+        return config

--- a/backend/pipeline/config.py
+++ b/backend/pipeline/config.py
@@ -1,31 +1,20 @@
-"""Pipeline configuration and logging setup.
+"""Pipeline run configuration.
 
-Story 1.1 installs the logging hook and a stub :class:`PipelineConfig`.
-The full config surface (thresholds, LLM provider selection, rendering
-options, baseline paths) lands in Story 1.6 when the orchestrator needs
-it end-to-end. Do not expand this dataclass ad-hoc — wait for Story 1.6
-so the schema is designed as a coherent whole.
+Story 1.1 installs a stub :class:`PipelineConfig`. The full config surface
+(thresholds, LLM provider selection, rendering options, baseline paths) lands
+in Story 1.6 when the orchestrator needs it end-to-end. Do not expand this
+dataclass ad-hoc — wait for Story 1.6 so the schema is designed as a coherent
+whole.
 
-Logging discipline (enforced here):
-
-* All log output is JSON on stderr, one event per line.
-* Every event carries ``pipeline_run_id`` once :func:`bind_pipeline_run_id`
-  has been called — contextvars propagate across threads and async tasks
-  without threading the ID through every call site.
-* Callers — CLI entrypoints, FastAPI startup, pytest session — MUST call
-  :func:`configure_logging` explicitly. This module never self-configures
-  at import time; that would make test isolation and library usage
-  impossible.
-* :mod:`logging.basicConfig` is never called (architecture.md:542
-  anti-pattern — the stdlib handler would compete with structlog and
-  produce mixed plain-text / JSON output).
+Logging setup (``configure_logging``, ``bind_pipeline_run_id``,
+``scoped_pipeline_run_id``) lives in :mod:`backend.core.logging` as of
+Story 2.2b — moved out of this module so that neither ``pipeline/`` nor
+``agents/`` has to import the other's package for structured logging.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-import structlog
 
 
 @dataclass
@@ -36,33 +25,3 @@ class PipelineConfig:
     empty here so downstream modules can import the symbol without a
     circular dependency on config shape that is not yet designed.
     """
-
-
-def configure_logging() -> None:
-    """Install the structlog processor chain for JSON output.
-
-    Idempotent — safe to call multiple times (for example, once from the
-    CLI and again from a pytest session-scoped fixture). Must be invoked
-    before any ``structlog.get_logger()`` call that expects JSON output.
-    """
-    structlog.configure(
-        processors=[
-            structlog.contextvars.merge_contextvars,
-            structlog.processors.add_log_level,
-            structlog.processors.TimeStamper(fmt="iso", utc=True),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.processors.JSONRenderer(),
-        ],
-    )
-
-
-def bind_pipeline_run_id(run_id: str) -> None:
-    """Bind ``pipeline_run_id=<run_id>`` to the current context.
-
-    Every subsequent log event emitted on the same thread / asyncio task
-    will carry this key until it is explicitly cleared or the context
-    ends. Use :func:`structlog.contextvars.clear_contextvars` to reset
-    between runs in long-lived processes.
-    """
-    structlog.contextvars.bind_contextvars(pipeline_run_id=run_id)

--- a/backend/pipeline/config.py
+++ b/backend/pipeline/config.py
@@ -1,10 +1,9 @@
 """Pipeline run configuration.
 
-Story 1.1 installs a stub :class:`PipelineConfig`. The full config surface
-(thresholds, LLM provider selection, rendering options, baseline paths) lands
-in Story 1.6 when the orchestrator needs it end-to-end. Do not expand this
-dataclass ad-hoc — wait for Story 1.6 so the schema is designed as a coherent
-whole.
+:class:`PipelineConfig` is defined in :mod:`backend.models.pipeline_config`
+(Story 2.1) — the models layer, alongside every other Pydantic contract. It is
+re-exported here so ``from backend.pipeline.config import PipelineConfig``
+(the import path the project's epics doc implies) keeps working.
 
 Logging setup (``configure_logging``, ``bind_pipeline_run_id``,
 ``scoped_pipeline_run_id``) lives in :mod:`backend.core.logging` as of
@@ -14,14 +13,6 @@ Story 2.2b — moved out of this module so that neither ``pipeline/`` nor
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from backend.models.pipeline_config import PipelineConfig
 
-
-@dataclass
-class PipelineConfig:
-    """Pipeline configuration stub.
-
-    Full schema is defined in Story 1.6 (orchestrator). Intentionally
-    empty here so downstream modules can import the symbol without a
-    circular dependency on config shape that is not yet designed.
-    """
+__all__ = ["PipelineConfig"]

--- a/backend/pipeline/narrative_generator.py
+++ b/backend/pipeline/narrative_generator.py
@@ -1,286 +1,36 @@
 """NarrativeGenerator — Stage 3: LLM narrative grounded in computed stats.
 
 Transforms an :class:`InsightPayload` (deterministic statistics from the
-Insight Engine) into an :class:`InsightReport` (structured prose) using
-Claude Structured Outputs.
+Insight Engine) into an :class:`InsightReport` (structured prose).
 
-Resilience layers (architecture.md §525-529):
-
-1. **Retry** — 3 attempts per provider, exponential backoff (1s, 2s, 4s).
-2. **Fallback** — Claude → OpenAI → Gemini.
-3. **Circuit breaker** — 3 consecutive provider-level failures → skip
-   narrative, return a fallback InsightReport so the pipeline continues.
-4. **4xx guard** — client errors are never retried (they indicate a code
-   bug, not a transient failure).
+As of Story 2.2 this class is a thin Stage-3 adapter: the retry / fallback /
+circuit-breaker resilience logic lives in :class:`backend.core.llm_client.LLMClient`
+so the Reporting Agent (2.3) and Monitoring Agent (2.4) can reuse it without
+duplication. This file only serializes the payload and delegates.
 """
 
 from __future__ import annotations
 
-import os
-import time
-from typing import Any
-
-import structlog
-
-from backend.errors.exceptions import LLMProviderError
+from backend.core.llm_client import LLMClient
 from backend.models.insight_payload import InsightPayload
-from backend.models.insight_report import InsightReport, NarrativeContent
-from backend.pipeline.config import bind_pipeline_run_id
-
-_BACKOFF_DELAYS = [1, 2, 4]
-_MAX_ATTEMPTS = 3
-_CIRCUIT_BREAKER_THRESHOLD = 3
-
-# Provider model identifiers. Keep these current — retired snapshots return
-# 404 at call time, which the retry/fallback machinery masks as a transient
-# failure. ``claude-sonnet-4-6`` is the current Sonnet (the older
-# ``claude-sonnet-4-20250514`` snapshot retired 2026-06-15).
-_CLAUDE_MODEL = "claude-sonnet-4-6"
-_OPENAI_MODEL = "gpt-4o"
-_GEMINI_MODEL = "gemini-2.0-flash"
-
-_SYSTEM_PROMPT = (
-    "You are a data analyst writing a professional narrative report. "
-    "You will receive a JSON payload of pre-computed statistics. "
-    "Your job is to NARRATE these statistics into clear, professional prose. "
-    "CRITICAL RULES:\n"
-    "- Reference ONLY numbers that appear in the provided data.\n"
-    "- Do NOT independently compute, invent, or hallucinate any numerical values.\n"
-    "- Do NOT perform any arithmetic on the provided numbers.\n"
-    "- Write in third person, professional tone.\n"
-    "- Structure your response with these fields: executive_summary, "
-    "key_findings (list of titled sections), anomaly_analysis (if anomalies exist), "
-    "and recommendations_narrative (if recommendations exist)."
-)
+from backend.models.insight_report import InsightReport
 
 
 class NarrativeGenerator:
     """Generates narrative prose from computed statistics via LLM."""
 
     def __init__(self) -> None:
-        self._logger = structlog.get_logger().bind(stage="narrative_generator")
+        self._client = LLMClient()
 
     def generate(
         self,
         insight_payload: InsightPayload,
         pipeline_run_id: str,
     ) -> InsightReport:
-        """Transform an InsightPayload into a narrated InsightReport.
+        """Serialize the payload and delegate to :class:`LLMClient`.
 
-        Tries Claude first, then OpenAI, then Gemini. Each provider gets
-        up to 3 retry attempts with exponential backoff. If all providers
-        fail, returns a fallback InsightReport.
+        The public call surface is unchanged — the orchestrator still calls
+        ``NarrativeGenerator().generate(payload, run_id)`` as Stage 3.
         """
-        bind_pipeline_run_id(pipeline_run_id)
         payload_json = insight_payload.model_dump_json()
-
-        providers: list[tuple[str, Any]] = [
-            ("claude", self._call_claude),
-            ("openai", self._call_openai),
-            ("gemini", self._call_gemini),
-        ]
-
-        consecutive_failures = 0
-        providers_tried: list[str] = []
-
-        for i, (provider_name, call_fn) in enumerate(providers):
-            if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
-                break
-
-            providers_tried.append(provider_name)
-
-            try:
-                report = self._try_provider(
-                    provider_name, call_fn, payload_json,
-                )
-                self._logger.info(
-                    "narrative_generated",
-                    provider=provider_name,
-                    model=report.metadata.get("model", "unknown"),
-                    token_count=report.metadata.get("token_count", 0),
-                    duration_ms=report.metadata.get("duration_ms", 0),
-                )
-                return report
-
-            except LLMProviderError:
-                raise
-
-            except Exception:
-                consecutive_failures += 1
-
-                if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
-                    break
-
-                if i + 1 < len(providers):
-                    next_provider = providers[i + 1][0]
-                    self._logger.warning(
-                        "llm_fallback",
-                        from_provider=provider_name,
-                        to_provider=next_provider,
-                        reason="all_attempts_exhausted",
-                    )
-
-        self._logger.error(
-            "llm_circuit_breaker",
-            consecutive_failures=consecutive_failures,
-            providers_tried=providers_tried,
-        )
-        return InsightReport(
-            executive_summary="",
-            key_findings=[],
-            metadata={
-                "provider": "none",
-                "fallback": True,
-                "providers_tried": providers_tried,
-            },
-            fallback=True,
-            fallback_reason=(
-                f"All LLM providers failed after {consecutive_failures} "
-                "consecutive failures"
-            ),
-        )
-
-    def _try_provider(
-        self,
-        provider_name: str,
-        call_fn: Any,
-        payload_json: str,
-    ) -> InsightReport:
-        """Attempt up to ``_MAX_ATTEMPTS`` calls to a single provider."""
-        last_exc: Exception | None = None
-
-        for attempt in range(1, _MAX_ATTEMPTS + 1):
-            try:
-                start = time.perf_counter()
-                report = call_fn(payload_json)
-                duration_ms = int((time.perf_counter() - start) * 1000)
-                report.metadata["duration_ms"] = duration_ms
-                return report
-
-            except Exception as exc:
-                if self._is_client_error(exc):
-                    self._logger.error(
-                        "llm_client_error",
-                        provider=provider_name,
-                        status_code=getattr(exc, "status_code", None),
-                        error=str(exc),
-                    )
-                    raise LLMProviderError(
-                        f"Client error from {provider_name}",
-                        provider=provider_name,
-                        cause=exc,
-                    ) from exc
-
-                last_exc = exc
-                self._logger.warning(
-                    "llm_retry",
-                    provider=provider_name,
-                    attempt=attempt,
-                    error_type=type(exc).__name__,
-                    backoff_seconds=_BACKOFF_DELAYS[attempt - 1] if attempt <= len(_BACKOFF_DELAYS) else _BACKOFF_DELAYS[-1],
-                )
-
-                if attempt < _MAX_ATTEMPTS:
-                    time.sleep(_BACKOFF_DELAYS[attempt - 1])
-
-        raise last_exc  # type: ignore[misc]
-
-    def _is_client_error(self, exc: Exception) -> bool:
-        status = getattr(exc, "status_code", None)
-        if status is not None and 400 <= status < 500:
-            return True
-        return False
-
-    def _build_report(
-        self,
-        content: NarrativeContent,
-        *,
-        provider: str,
-        model: str,
-        token_count: int,
-    ) -> InsightReport:
-        """Compose the renderer-facing InsightReport from LLM narrative + telemetry.
-
-        ``metadata`` and ``fallback`` are set here (by code), never by the
-        model — the model only ever sees the :class:`NarrativeContent` schema.
-        """
-        return InsightReport(
-            **content.model_dump(),
-            metadata={
-                "provider": provider,
-                "model": model,
-                "token_count": token_count,
-            },
-            fallback=False,
-        )
-
-    def _build_prompt(self, payload_json: str) -> str:
-        return (
-            f"{_SYSTEM_PROMPT}\n\n"
-            f"Here is the computed data payload:\n{payload_json}"
-        )
-
-    def _call_claude(self, payload_json: str) -> InsightReport:
-        import anthropic
-
-        # max_retries=0 — this class implements its own retry/backoff loop; the
-        # SDK's default of 2 internal retries would compound with it.
-        client = anthropic.Anthropic(
-            api_key=os.environ.get("ANTHROPIC_API_KEY"), max_retries=0
-        )
-        result = client.messages.parse(
-            model=_CLAUDE_MODEL,
-            max_tokens=4096,
-            messages=[{"role": "user", "content": self._build_prompt(payload_json)}],
-            output_format=NarrativeContent,
-        )
-        content: NarrativeContent = result.parsed_output  # type: ignore[assignment]
-        token_count = getattr(result.usage, "output_tokens", 0) + getattr(
-            result.usage, "input_tokens", 0
-        )
-        return self._build_report(
-            content, provider="claude", model=_CLAUDE_MODEL, token_count=token_count
-        )
-
-    def _call_openai(self, payload_json: str) -> InsightReport:
-        import openai
-
-        client = openai.OpenAI(
-            api_key=os.environ.get("OPENAI_API_KEY"), max_retries=0
-        )
-        result = client.beta.chat.completions.parse(
-            model=_OPENAI_MODEL,
-            messages=[{"role": "user", "content": self._build_prompt(payload_json)}],
-            response_format=NarrativeContent,
-        )
-        content: NarrativeContent = result.choices[0].message.parsed  # type: ignore[assignment]
-        return self._build_report(
-            content,
-            provider="openai",
-            model=_OPENAI_MODEL,
-            token_count=getattr(result.usage, "total_tokens", 0),
-        )
-
-    def _call_gemini(self, payload_json: str) -> InsightReport:
-        import json
-
-        from google import genai
-
-        client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
-        result = client.models.generate_content(
-            model=_GEMINI_MODEL,
-            contents=self._build_prompt(payload_json),
-            config={
-                "response_mime_type": "application/json",
-                "response_schema": NarrativeContent,
-            },
-        )
-        content = NarrativeContent.model_validate(json.loads(result.text))
-        return self._build_report(
-            content,
-            provider="gemini",
-            model=_GEMINI_MODEL,
-            token_count=getattr(
-                getattr(result, "usage_metadata", None), "total_token_count", 0
-            ),
-        )
+        return self._client.generate_narrative(payload_json, pipeline_run_id)

--- a/backend/pipeline/orchestrator.py
+++ b/backend/pipeline/orchestrator.py
@@ -29,9 +29,9 @@ import pandas as pd
 import structlog
 import typer
 
+from backend.core.logging import bind_pipeline_run_id, configure_logging
 from backend.errors.exceptions import ConfigurationError, SavvyCleanseError
 from backend.models.pipeline_result import PipelineResult
-from backend.pipeline.config import bind_pipeline_run_id, configure_logging
 from backend.pipeline.data_quality import DataQualityAssessor
 from backend.pipeline.insight_engine import InsightEngine
 from backend.pipeline.narrative_generator import NarrativeGenerator

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,3 +28,8 @@ structlog==25.5.0      # JSON structured logging with correlation IDs
 pytest>=8.2            # Test runner (pyproject pins exact config)
 pytest-cov             # Coverage reporting
 python-dotenv>=1.0     # .env loader for local development
+
+# --- Phase 2 configuration layer (added Story 2.1) ---
+pyyaml>=6.0            # config.yaml parsing (safe_load only)
+croniter>=2.0          # cron expression validation for report_schedule
+email-validator>=2.0   # required by Pydantic EmailStr (alert_recipients)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from backend.pipeline.config import configure_logging
+from backend.core.logging import configure_logging
 
 # Defect-seeding indices for dirty_sales_df — kept as module constants so
 # test assertions can reference the exact positions rather than magic

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,301 @@
+"""Tests for the Configuration Layer (Story 2.1).
+
+Covers: valid config, missing required fields, invalid values (bad cron,
+negative threshold, bad email), environment-variable override for secrets,
+reload-reflects-changes behavior, and the config_loaded log event.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import structlog
+
+from backend.errors.exceptions import ConfigurationError
+from backend.models.pipeline_config import PipelineConfig
+
+VALID_CONFIG = """
+data_sources:
+  - data/sales.csv
+
+report_schedule:
+  interval: weekly
+
+metric_thresholds:
+  revenue: 0.15
+  units_sold: 0.20
+
+alert_recipients:
+  - ops@example.com
+
+output:
+  format: docx
+  output_dir: output/
+"""
+
+
+def _write_config(tmp_path: Path, content: str) -> Path:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(content, encoding="utf-8")
+    return config_path
+
+
+class TestValidConfig:
+    def test_loads_typed_config_with_declared_values(self, tmp_path: Path) -> None:
+        config_path = _write_config(tmp_path, VALID_CONFIG)
+
+        config = PipelineConfig.load(config_path)
+
+        assert isinstance(config, PipelineConfig)
+        assert config.data_sources.paths == ["data/sales.csv"]
+        assert config.report_schedule.interval == "weekly"
+        assert config.report_schedule.cron is None
+        assert config.metric_thresholds.thresholds == {
+            "revenue": 0.15,
+            "units_sold": 0.20,
+        }
+        assert config.alert_recipients.recipients == ["ops@example.com"]
+        assert config.output.format == "docx"
+
+    def test_defaults_applied_when_optional_sections_omitted(
+        self, tmp_path: Path
+    ) -> None:
+        minimal = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: daily
+"""
+        config = PipelineConfig.load(_write_config(tmp_path, minimal))
+
+        assert config.metric_thresholds.thresholds == {}
+        assert config.metric_thresholds.get("revenue") == 0.15
+        assert config.alert_recipients.recipients == []
+        assert config.output.format == "docx"
+        assert config.output.output_dir == "output/"
+
+    def test_missing_config_file_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(tmp_path / "does-not-exist.yaml")
+
+    def test_malformed_yaml_raises_configuration_error(self, tmp_path: Path) -> None:
+        config_path = _write_config(tmp_path, "data_sources: [unterminated")
+
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(config_path)
+
+
+class TestMissingRequiredFields:
+    def test_missing_data_sources_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        content = """
+report_schedule:
+  interval: daily
+"""
+        with pytest.raises(ConfigurationError, match="data_sources"):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_missing_report_schedule_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        content = """
+data_sources:
+  - data/sales.csv
+"""
+        with pytest.raises(ConfigurationError, match="report_schedule"):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_empty_data_sources_list_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        content = """
+data_sources: []
+report_schedule:
+  interval: daily
+"""
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+
+class TestInvalidValues:
+    def test_invalid_cron_expression_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        content = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  cron: "not a cron expression"
+"""
+        with pytest.raises(ConfigurationError, match="cron"):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_interval_and_cron_both_set_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        content = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: daily
+  cron: "0 6 * * 1"
+"""
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_negative_threshold_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        content = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: daily
+metric_thresholds:
+  revenue: -0.15
+"""
+        with pytest.raises(ConfigurationError, match="revenue"):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_zero_threshold_raises_configuration_error(self, tmp_path: Path) -> None:
+        content = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: daily
+metric_thresholds:
+  revenue: 0
+"""
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_malformed_email_raises_configuration_error(self, tmp_path: Path) -> None:
+        content = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: daily
+alert_recipients:
+  - not-an-email
+"""
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_data_sources_as_mapping_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A YAML indentation mistake (mapping instead of a list) must be
+        rejected, not silently accepted as an empty data_sources list.
+        """
+        content = """
+data_sources:
+  file: data/sales.csv
+report_schedule:
+  interval: daily
+"""
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+    def test_alert_recipients_as_mapping_raises_configuration_error(
+        self, tmp_path: Path
+    ) -> None:
+        """A YAML indentation mistake (mapping instead of a list) must be
+        rejected, not silently accepted as an empty alert_recipients list.
+        """
+        content = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: daily
+alert_recipients:
+  primary: ops@example.com
+"""
+        with pytest.raises(ConfigurationError):
+            PipelineConfig.load(_write_config(tmp_path, content))
+
+
+class TestEnvironmentOverride:
+    def test_smtp_password_sourced_from_env_not_yaml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+        monkeypatch.setenv("SMTP_USERNAME", "alerts@example.com")
+        monkeypatch.setenv("SMTP_PASSWORD", "super-secret-value")
+        monkeypatch.setenv("SMTP_FROM", "alerts@example.com")
+
+        config_path = _write_config(tmp_path, VALID_CONFIG)
+        config = PipelineConfig.load(config_path)
+
+        assert config.smtp.password == "super-secret-value"
+        assert config.smtp.host == "smtp.example.com"
+        # The secret never appears anywhere in the YAML on disk.
+        assert "super-secret-value" not in config_path.read_text(encoding="utf-8")
+
+    def test_smtp_settings_absent_from_yaml_are_still_populated_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SMTP_PASSWORD", "another-secret")
+        config_path = _write_config(tmp_path, VALID_CONFIG)
+
+        config = PipelineConfig.load(config_path)
+
+        assert config.smtp.password == "another-secret"
+
+
+class TestReload:
+    def test_second_load_reflects_file_changes(self, tmp_path: Path) -> None:
+        content_v1 = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: daily
+metric_thresholds:
+  revenue: 0.15
+"""
+        content_v2 = """
+data_sources:
+  - data/sales.csv
+report_schedule:
+  interval: monthly
+metric_thresholds:
+  revenue: 0.30
+"""
+        config_path = _write_config(tmp_path, content_v1)
+
+        first = PipelineConfig.load(config_path)
+        assert first.report_schedule.interval == "daily"
+        assert first.metric_thresholds.thresholds["revenue"] == 0.15
+
+        config_path.write_text(content_v2, encoding="utf-8")
+        second = PipelineConfig.load(config_path)
+
+        assert second.report_schedule.interval == "monthly"
+        assert second.metric_thresholds.thresholds["revenue"] == 0.30
+
+
+class TestObservability:
+    def test_config_loaded_event_emitted_with_no_secrets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SMTP_PASSWORD", "should-never-be-logged")
+        config_path = _write_config(tmp_path, VALID_CONFIG)
+
+        with structlog.testing.capture_logs() as captured:
+            PipelineConfig.load(config_path)
+
+        events = [e for e in captured if e.get("event") == "config_loaded"]
+        assert len(events) == 1
+
+        event = events[0]
+        assert event["schedule"] == "weekly"
+        assert event["threshold_keys"] == ["revenue", "units_sold"]
+        assert event["recipient_count"] == 1
+        assert event["output_format"] == "docx"
+
+        payload_str = str(event)
+        assert "should-never-be-logged" not in payload_str
+        assert "ops@example.com" not in payload_str

--- a/backend/tests/test_insight_engine.py
+++ b/backend/tests/test_insight_engine.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pytest
 import structlog
 
+from backend.core.logging import configure_logging
 from backend.models.insight_payload import (
     AnomalyRecord,
     ColumnSummary,
@@ -28,7 +29,6 @@ from backend.models.quality_report import (
     DefectCategory,
     Severity,
 )
-from backend.pipeline.config import configure_logging
 from backend.pipeline.insight_engine import InsightEngine
 
 

--- a/backend/tests/test_llm_client_hardening.py
+++ b/backend/tests/test_llm_client_hardening.py
@@ -1,0 +1,102 @@
+"""Tests for Story 2.2b — LLMClient hardening for multi-caller use.
+
+Covers the three findings from the Story 2.2 code review:
+- AC2: JSON logging is guaranteed for callers who never call configure_logging(),
+  without clobbering a caller/test that already configured structlog.
+- AC3: pipeline_run_id binding is scoped to the call and does not leak into (or
+  clear) the ambient contextvars state.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import structlog
+from structlog.testing import LogCapture
+
+from backend.core.llm_client import LLMClient
+from backend.core.logging import bind_pipeline_run_id, configure_logging
+from backend.models.insight_report import InsightReport, NarrativeSection
+
+
+def _sample_report() -> InsightReport:
+    return InsightReport(
+        executive_summary="Summary.",
+        key_findings=[NarrativeSection(title="A", content="B")],
+        metadata={"provider": "claude", "model": "claude-sonnet-4-6", "token_count": 10},
+    )
+
+
+class TestDoesNotClobberExistingConfig:
+    def test_generate_narrative_preserves_log_capture(self) -> None:
+        """A caller/test that already configured structlog (e.g. a LogCapture
+        fixture) must still see its own events after generate_narrative() runs —
+        ensure_logging_configured() must not reconfigure structlog out from under it.
+        """
+        cap = LogCapture()
+        structlog.configure(
+            processors=[
+                structlog.contextvars.merge_contextvars,
+                structlog.processors.add_log_level,
+                cap,
+            ],
+        )
+        try:
+            client = LLMClient()
+            with patch.object(client, "_call_claude", return_value=_sample_report()):
+                client.generate_narrative("{}", "run-cap")
+
+            events = [e for e in cap.entries if e.get("event") == "narrative_generated"]
+            assert len(events) == 1
+        finally:
+            configure_logging()
+
+
+class TestConfiguresWhenUnconfigured:
+    def test_generate_narrative_configures_json_logging(self) -> None:
+        """A caller that never calls configure_logging() itself still gets JSON
+        output — generate_narrative() must configure it when nothing else has.
+        """
+        structlog.reset_defaults()
+        assert not structlog.is_configured()
+        try:
+            client = LLMClient()
+            with patch.object(client, "_call_claude", return_value=_sample_report()):
+                client.generate_narrative("{}", "run-unconf")
+
+            assert structlog.is_configured()
+        finally:
+            configure_logging()
+
+
+class TestScopedBindingDoesNotLeak:
+    def test_pipeline_run_id_removed_after_call_with_no_prior_binding(self) -> None:
+        """A direct caller with no ambient pipeline_run_id must not leak one into
+        later log lines on the same thread/task after the call returns.
+        """
+        configure_logging()
+        structlog.contextvars.clear_contextvars()
+
+        client = LLMClient()
+        with patch.object(client, "_call_claude", return_value=_sample_report()):
+            client.generate_narrative("{}", "run-A")
+
+        assert "pipeline_run_id" not in structlog.contextvars.get_contextvars()
+
+    def test_pipeline_run_id_restored_after_call_with_prior_binding(self) -> None:
+        """The orchestrator pattern: pipeline_run_id is bound once for the whole
+        run before Stage 3 runs, and must still be present (not cleared) for
+        Stage 4 logging after generate_narrative() returns.
+        """
+        configure_logging()
+        structlog.contextvars.clear_contextvars()
+        bind_pipeline_run_id("run-outer")
+
+        client = LLMClient()
+        with patch.object(client, "_call_claude", return_value=_sample_report()):
+            client.generate_narrative("{}", "run-outer")
+
+        assert (
+            structlog.contextvars.get_contextvars().get("pipeline_run_id")
+            == "run-outer"
+        )

--- a/backend/tests/test_narrative_generator.py
+++ b/backend/tests/test_narrative_generator.py
@@ -17,6 +17,7 @@ import structlog
 from structlog.testing import LogCapture
 
 from backend.core.llm_client import LLMClient
+from backend.core.logging import configure_logging
 from backend.errors.exceptions import LLMProviderError
 from backend.models.insight_payload import InsightPayload
 from backend.models.insight_report import (
@@ -24,7 +25,6 @@ from backend.models.insight_report import (
     NarrativeContent,
     NarrativeSection,
 )
-from backend.pipeline.config import configure_logging
 from backend.pipeline.narrative_generator import NarrativeGenerator
 
 

--- a/backend/tests/test_narrative_generator.py
+++ b/backend/tests/test_narrative_generator.py
@@ -16,6 +16,7 @@ import pytest
 import structlog
 from structlog.testing import LogCapture
 
+from backend.core.llm_client import LLMClient
 from backend.errors.exceptions import LLMProviderError
 from backend.models.insight_payload import InsightPayload
 from backend.models.insight_report import (
@@ -96,7 +97,7 @@ class TestSuccessfulGeneration:
         mock_result.usage.output_tokens = 200
         mock_result.usage.input_tokens = 150
 
-        with patch.object(gen, "_call_claude", return_value=sample_report):
+        with patch("backend.core.llm_client.LLMClient._call_claude", return_value=sample_report):
             result = gen.generate(insight_payload, pipeline_run_id)
 
         assert isinstance(result, InsightReport)
@@ -113,7 +114,7 @@ class TestSuccessfulGeneration:
     ) -> None:
         gen = NarrativeGenerator()
 
-        with patch.object(gen, "_call_claude", return_value=sample_report):
+        with patch("backend.core.llm_client.LLMClient._call_claude", return_value=sample_report):
             gen.generate(insight_payload, pipeline_run_id)
 
         events = [e for e in log_capture.entries if e.get("event") == "narrative_generated"]
@@ -143,8 +144,8 @@ class TestRetryLogic:
             return sample_report
 
         with (
-            patch.object(gen, "_call_claude", side_effect=_mock_claude),
-            patch("backend.pipeline.narrative_generator.time.sleep") as mock_sleep,
+            patch("backend.core.llm_client.LLMClient._call_claude", side_effect=_mock_claude),
+            patch("backend.core.llm_client.time.sleep") as mock_sleep,
         ):
             result = gen.generate(insight_payload, pipeline_run_id)
 
@@ -173,8 +174,8 @@ class TestRetryLogic:
             return sample_report
 
         with (
-            patch.object(gen, "_call_claude", side_effect=_mock_claude),
-            patch("backend.pipeline.narrative_generator.time.sleep"),
+            patch("backend.core.llm_client.LLMClient._call_claude", side_effect=_mock_claude),
+            patch("backend.core.llm_client.time.sleep"),
         ):
             gen.generate(insight_payload, pipeline_run_id)
 
@@ -203,9 +204,9 @@ class TestFallbackChain:
         )
 
         with (
-            patch.object(gen, "_call_claude", side_effect=_make_timeout_error()),
-            patch.object(gen, "_call_openai", return_value=openai_report),
-            patch("backend.pipeline.narrative_generator.time.sleep"),
+            patch("backend.core.llm_client.LLMClient._call_claude", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.LLMClient._call_openai", return_value=openai_report),
+            patch("backend.core.llm_client.time.sleep"),
         ):
             result = gen.generate(insight_payload, pipeline_run_id)
 
@@ -232,10 +233,10 @@ class TestFallbackChain:
         )
 
         with (
-            patch.object(gen, "_call_claude", side_effect=_make_timeout_error()),
-            patch.object(gen, "_call_openai", side_effect=_make_timeout_error()),
-            patch.object(gen, "_call_gemini", return_value=gemini_report),
-            patch("backend.pipeline.narrative_generator.time.sleep"),
+            patch("backend.core.llm_client.LLMClient._call_claude", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.LLMClient._call_openai", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.LLMClient._call_gemini", return_value=gemini_report),
+            patch("backend.core.llm_client.time.sleep"),
         ):
             result = gen.generate(insight_payload, pipeline_run_id)
 
@@ -255,10 +256,10 @@ class TestCircuitBreaker:
         gen = NarrativeGenerator()
 
         with (
-            patch.object(gen, "_call_claude", side_effect=_make_timeout_error()),
-            patch.object(gen, "_call_openai", side_effect=_make_timeout_error()),
-            patch.object(gen, "_call_gemini", side_effect=_make_timeout_error()),
-            patch("backend.pipeline.narrative_generator.time.sleep"),
+            patch("backend.core.llm_client.LLMClient._call_claude", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.LLMClient._call_openai", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.LLMClient._call_gemini", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.time.sleep"),
         ):
             result = gen.generate(insight_payload, pipeline_run_id)
 
@@ -276,10 +277,10 @@ class TestCircuitBreaker:
         gen = NarrativeGenerator()
 
         with (
-            patch.object(gen, "_call_claude", side_effect=_make_timeout_error()),
-            patch.object(gen, "_call_openai", side_effect=_make_timeout_error()),
-            patch.object(gen, "_call_gemini", side_effect=_make_timeout_error()),
-            patch("backend.pipeline.narrative_generator.time.sleep"),
+            patch("backend.core.llm_client.LLMClient._call_claude", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.LLMClient._call_openai", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.LLMClient._call_gemini", side_effect=_make_timeout_error()),
+            patch("backend.core.llm_client.time.sleep"),
         ):
             gen.generate(insight_payload, pipeline_run_id)
 
@@ -300,8 +301,8 @@ class TestClientErrorNonRetry:
         gen = NarrativeGenerator()
 
         with (
-            patch.object(
-                gen, "_call_claude",
+            patch(
+                "backend.core.llm_client.LLMClient._call_claude",
                 side_effect=_make_api_status_error(400, "Bad request"),
             ),
             pytest.raises(LLMProviderError) as exc_info,
@@ -328,7 +329,7 @@ class TestClientErrorNonRetry:
             raise original_exc
 
         with (
-            patch.object(gen, "_call_claude", side_effect=_mock_claude),
+            patch("backend.core.llm_client.LLMClient._call_claude", side_effect=_mock_claude),
             pytest.raises(LLMProviderError),
         ):
             gen.generate(insight_payload, pipeline_run_id)
@@ -344,8 +345,8 @@ class TestClientErrorNonRetry:
         gen = NarrativeGenerator()
 
         with (
-            patch.object(
-                gen, "_call_claude",
+            patch(
+                "backend.core.llm_client.LLMClient._call_claude",
                 side_effect=_make_api_status_error(422, "Unprocessable"),
             ),
             pytest.raises(LLMProviderError),
@@ -369,7 +370,7 @@ class TestClaudeProviderBody:
     def test_uses_current_model_and_parsed_output(self) -> None:
         anthropic = pytest.importorskip("anthropic")
 
-        gen = NarrativeGenerator()
+        client = LLMClient()
         parsed = NarrativeContent(
             executive_summary="Grounded summary.",
             key_findings=[NarrativeSection(title="A", content="B")],
@@ -383,7 +384,7 @@ class TestClaudeProviderBody:
         mock_client.messages.parse.return_value = mock_result
 
         with patch.object(anthropic, "Anthropic", return_value=mock_client) as mock_ctor:
-            report = gen._call_claude("{}")
+            report = client._call_claude("{}")
 
         # The provider was asked for the current Sonnet, not a retired snapshot.
         _, parse_kwargs = mock_client.messages.parse.call_args

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,19 @@
+# SavvyCortex pipeline configuration (Phase 2). Secrets live in .env, NOT here.
+
+data_sources:
+  - data/sales.csv            # file path(s) or directory(ies) the agents pull from
+
+report_schedule:
+  interval: weekly            # one of: daily | weekly | monthly
+  # cron: "0 6 * * 1"         # OR a cron expression (mutually exclusive with interval)
+
+metric_thresholds:            # per-metric fractional change; 0.15 == ±15%
+  revenue: 0.15
+  units_sold: 0.20
+
+alert_recipients:
+  - ops@example.com
+
+output:
+  format: docx                # docx | pdf
+  output_dir: output/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
     "pydantic>=2.0",
     "typer>=0.12.1",
     "pandas>=2.0",
+    "pyyaml>=6.0",
+    "croniter>=2.0",
+    "email-validator>=2.0",
+    "python-dotenv>=1.0",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -132,6 +132,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/35/96ad0a71eb0b27ab4476a7ed23facd0713d82da9c911edc8af7f34a62d6a/croniter-6.2.3.tar.gz", hash = "sha256:fb129986ef7e2c44e3f4c9f503da83ad914d2afa48f40a43ee3dca4b5c41d476", size = 166174, upload-time = "2026-07-02T14:34:22.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/dd/6466498a8b69754cffbd7237ce4c66446ca5ffcf53fb397d437666f056d2/croniter-6.2.3-py3-none-any.whl", hash = "sha256:137a97001b4d52fb71c10b750e303db79e6e42d40fff8ff77126102176c9f786", size = 46446, upload-time = "2026-07-02T14:34:20.889Z" },
+]
+
+[[package]]
 name = "cssselect2"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -142,6 +154,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -156,6 +177,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/b4/4435f3fcb1357ec441079c4af1dda3ea926fad6dcead4aed2d93b369944e/docxtpl-0.20.2.tar.gz", hash = "sha256:eddf3350d70b4d123208e801d585bcb313d21044a377a14f75a66d0965841de1", size = 17890, upload-time = "2025-11-13T12:47:15.943Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ad/e07939d8e020e513d3860400413ba1e0e06102c469639b440d921337efef/docxtpl-0.20.2-py3-none-any.whl", hash = "sha256:626d5c570a46a62b2ca73b4d08f1c240fa031a5bc45371e1466a4fe184923d10", size = 17881, upload-time = "2025-11-13T12:47:13.704Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -196,6 +230,15 @@ woff = [
     { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
     { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
     { name = "zopfli" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -620,6 +663,51 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -637,10 +725,14 @@ name = "savvycortex"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "croniter" },
     { name = "docxtpl" },
+    { name = "email-validator" },
     { name = "jinja2" },
     { name = "pandas" },
     { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "structlog" },
     { name = "typer" },
     { name = "weasyprint" },
@@ -648,10 +740,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "croniter", specifier = ">=2.0" },
     { name = "docxtpl", specifier = ">=0.20.2" },
+    { name = "email-validator", specifier = ">=2.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0" },
     { name = "typer", specifier = ">=0.12.1" },
     { name = "weasyprint", specifier = ">=68.1" },


### PR DESCRIPTION
## Summary

Delivers the foundational core-services work for **Epic 2 (Automated Reporting & Data Monitoring)**: a shared LLM client abstraction, a typed configuration layer, and the SM housekeeping that files the next story (Drift Engine) with a numbering reconciliation. All three stories are implemented, reviewed, and marked `done` in `sprint-status.yaml`.

## What changed

**Story 2.2 — LLM client abstraction** (`ced6864`)
- Extracted LLM resilience logic (retries, error handling) out of `narrative_generator.py` into a new shared `backend/core/llm_client.py` (~308 lines). Zero behavior change — the narrative generator now calls through the abstraction.
- Adds `backend/core/logging.py` and `backend/core/__init__.py`.

**Story 2.2b — Harden LLMClient for multi-caller use** (`0599cb7`)
- Corrective story raised by 2.2's code review. Hardens `LLMClient` so the upcoming Reporting (2.4) and Monitoring (2.5) agents can safely share one client instance.
- New coverage in `test_llm_client_hardening.py`. Re-reviewed with 0 findings.

**Story 2.1 — Configuration layer** (`a0a7b50`, `d4808e4`)
- New `backend/models/pipeline_config.py` — typed, validated pipeline configuration (data sources, report schedule, per-metric thresholds, alert recipients, output format).
- `config.yaml` / `.env.example` updated to document the config surface. One review fix applied (mapping-vs-list silent-swallow bug).
- New `test_config.py` (301 lines).

**SM chore — Story 2.3 (Drift Engine) + Epic 2 renumbering** (`055118c`)
- Files the ready-for-dev Drift Engine story.
- Reconciles Epic 2 numbering: the out-of-band LLM-client story took the `2.2` slot, so Drift Engine moved 2.2 → 2.3, Reporting → 2.4, Monitoring → 2.5. The filed numbers in `sprint-status.yaml` are authoritative; the story header carries the full mapping.

## Why

The Reporting and Monitoring agents (2.4 / 2.5) both need to call an LLM and read typed config. Landing the shared `LLMClient` and `PipelineConfig` first means those agents build on one hardened abstraction instead of duplicating resilience/parsing logic. Drift Engine (2.3) is sequenced next because the reporting pipeline (DQA → Drift → Insights → Narrative → Render) depends on it.

## Reviewer notes

- **Two distinct threshold concepts — do not conflate:** `PipelineConfig.metric_thresholds` (user-configurable, consumed by the Monitoring Agent) vs. the Drift Engine's fixed HIGH/MEDIUM/LOW severity bands. Called out in the 2.3 story header.
- `narrative_generator.py` shrank by ~274 lines — that logic moved into `core/llm_client.py`, not deleted.
- No production runtime behavior change from 2.2 (pure extraction); 2.1 and 2.2b add new capability + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
