### PR TITLE
docs(R.1): correct code-rename scope against the real tree (no execution)

### DIFF
--- a/_bmad-output/implementation-artifacts/R-1-code-rename-savvycortex-to-saint.md
+++ b/_bmad-output/implementation-artifacts/R-1-code-rename-savvycortex-to-saint.md
@@ -1,89 +1,83 @@
-# Story R.1: Code Rename — savvycortex → saint
+# Story R.1: Code Rename → SAINT
 
 Status: ready-for-dev
 
-Sizing: M · Model: Sonnet · loop_eligible: false
+Sizing: M (backend-only) / L (if frontend rebrand included) · Model: Sonnet · loop_eligible: false
 
-<!-- Filed 2026-07-09 roadmap restructure (Task 8). NOT executed here. This story aligns
-     the CODE to the SAINT documentation rename (Amendment 8, which was docs-only). -->
+<!-- Filed 2026-07-09 roadmap restructure (Task 8). CORRECTED 2026-07-11 against the actual
+     codebase — the original scope (inherited from the PRD §7.3 ASPIRATIONAL layout) did not
+     match reality. NOT executed. Scope is DEFERRED to deliberate human scheduling. -->
 
-## Story
+## ⚠️ Reality correction (2026-07-11) — read before scoping
 
-As the SAINT maintainer,
-I want the `savvycortex` code package and its references renamed to `saint`,
-so that the codebase matches the SAINT product name established in documentation
-(Amendment 8) — closing the deliberate, time-boxed doc-vs-code name mismatch.
+The PRD §7.3 file structure, Amendment 8, and the reconciliation NAME MISMATCH note all
+describe an **aspirational** `savvycortex/` package layout that was **never implemented**.
+Verified against the actual tree on main:
 
-## Scheduling (LOAD-BEARING)
+| Original R.1 / Amendment 8 assumption | Actual codebase |
+|---|---|
+| `savvycortex/` package directory | **Does not exist.** The Python package is `backend/`. |
+| `from savvycortex.*` imports | **None.** All imports are `from backend.*`. |
+| `backend.api.app:app` entrypoint | Exists (FastAPI title "SavvyCortex API"). Module is `backend.api.app`. |
+| Component filename `dqa_engine.py` (keep unchanged) | **Does not exist.** The DQA engine is `backend/pipeline/data_quality.py`. `drift_engine.py` does exist. |
+| Landing-page `import savvyclean as sc` code sample | **No such sample.** The entire frontend is brand-named **"SavvyClean"** (index.html + ~25 `src/` files). |
 
-Execute at the clean seam: **AFTER Story 2.5 merges, BEFORE Story 3.1 begins.**
-- Story 2.5 has merged (Epic 2 complete) — the "after 2.5" precondition is met.
-- Doing it during Story 2.5 means merge conflicts on `feat/story-2.5-monitoring-agent`.
-- Doing it during Epic 3 means renaming a package while writing a nine-story cleaning
-  engine into it. Both are avoided by executing now, with nothing in flight.
+**The product name in code is split, and neither half is a `savvycortex/` package:**
+- **Backend** carries "SavvyCortex" prose only (docstrings, Typer help, FastAPI title,
+  `pyproject.toml name = "savvycortex"`, exception-module docstring, and the alert email
+  Subject/from-address in `monitoring_agent.py`). The package directory is the neutral
+  name `backend/`, NOT the product name.
+- **Frontend** is client-facing branded **"SavvyClean"** across `index.html` (title + og
+  meta), `src/components/*` (Hero, Navbar, Footer, AnalysisTypes, Feedback, SignupForm,
+  AdminDashboard), and `src/pages/*`. Note: Amendment 8 says "SavvyClean was already
+  retired and must not reappear" — yet it is the currently-shipping public name. Retiring
+  it is a client-facing change, not a code-internal one.
 
-## Scope
+So R.1 **cannot be executed as originally written** (its targets don't exist). The genuine
+rename surface is different and must be scoped deliberately — hence this story stays
+`ready-for-dev` and is NOT auto-executed.
 
-- `savvycortex/` package directory → `saint/`
-- All `from savvycortex.*` imports across the codebase
-- `backend.api.app:app` entrypoint reference, if affected
-- Repo `savvy-cleanse-analysis` → renamed per Marvin's instruction (requires Marvin —
-  GitHub repo rename is a human action, not an in-repo edit)
-- Landing page code sample `import savvyclean as sc` → correct package name (`saint`)
+## Actual rename surface (by area)
 
-## Explicitly OUT of scope (must NOT change)
+- **A. Backend product-name (Python).** `pyproject.toml` `name`/`description`; "SavvyCortex"
+  prose in `backend/agents/reporting_agent.py`, `backend/agents/monitoring_agent.py`
+  (Typer help + email Subject/from-address), `backend/api/app.py` (FastAPI title),
+  `backend/errors/exceptions.py`, `backend/pipeline/orchestrator.py`, `backend/models/
+  pipeline_result.py`, and "NOT part of the SavvyCortex pipeline" comments in the legacy
+  modules (`advanced_pipeline.py`, `comprehensive_analytics.py`, `dashboard_api.py`,
+  `main.py`, `main_enhanced.py`, `nlp_processor.py`). The `backend/` package directory and
+  `from backend.*` imports are NOT the product name — leaving them is defensible.
+- **B. Frontend brand (SavvyClean → SAINT).** `index.html` title/meta + ~25 `src/` files.
+  Client-facing; wants its own visual/QA pass.
+- **C. Repo rename** `savvy-cleanse-analysis` → per Marvin's instruction. A GitHub action a
+  human performs; also `README.md` clone URL / `savvycleanse/` references.
+- **D. Non-code artifacts.** `README.md` badge, `config.yaml`, `daily_report.txt`,
+  `daily_ops.log`, `codex_handoff.yaml`, `pr_status.yaml`, `story.yaml` (as they are next
+  touched — not load-bearing).
+- **Optional / highest blast radius:** rename the `backend/` package → `saint/` (touches
+  every `from backend.*` import, `backend.api.app:app`, and all `python -m backend.*`
+  invocations). Not required by the product rename; only if explicitly desired.
 
-- Component filenames `dqa_engine.py` and `drift_engine.py` — UNCHANGED, permanently.
-  The previously-held "cosmetic rename" of these components is VOID; SAINT is the
-  product name, the components keep their current names. (Recorded so it does not
-  resurface.)
-- Any documentation rename — already done in the restructure (Amendment 8).
+## Scheduling (unchanged)
 
-## Acceptance Criteria
+Execute at the clean seam: **AFTER Story 2.5 merges (done), BEFORE Story 3.1 begins**, on its
+OWN branch, own test run, own PR, own merge. The blast radius (especially areas B/optional)
+is why this is `loop_eligible: false` with a human merge.
 
-1. `savvycortex/` package directory is renamed to `saint/`; the package imports and
-   runs under the new name.
-2. Every `from savvycortex.*` / `import savvycortex` reference across the codebase is
-   updated to `saint`. No `savvycortex` code identifier remains (documentation
-   references may remain historical, e.g. archived files and this story).
-3. The `backend.api.app:app` entrypoint (and any CLI `-m backend.*` invocations)
-   resolve under the renamed package.
-4. The landing-page code sample `import savvyclean as sc` is corrected to the real
-   package name.
-5. Component filenames `dqa_engine.py` and `drift_engine.py` are unchanged.
-6. **All tests pass post-rename before merge.** 181 tests currently pass (Epic 1: 6
-   stories; Epic 2: 2.3 = 154, 2.4 = 165, 2.5 = 181). The full suite must be 181
-   passed / 0 regressions after the rename (`uv run pytest backend/tests/
-   --ignore=backend/tests/test_parse_file.py`).
+## Acceptance Criteria (to be finalized when scope is chosen)
 
-## Constraints
+1. Chosen rename scope (A, A+B, or A+B+package) applied; no unintended identifiers changed.
+2. `drift_engine.py` and `data_quality.py` filenames unchanged (component filenames stable).
+3. **Full suite green post-rename** — 181 passed / 0 regressions (`uv run pytest backend/tests/
+   --ignore=backend/tests/test_parse_file.py`). If the frontend is in scope, the frontend
+   build/tests are green too.
+4. If area C is in scope: the GitHub repo-rename hand-off is flagged for Marvin (human action).
+5. Run /security-review; resolve any Critical/High.
 
-- OWN BRANCH (e.g. `chore/R1-code-rename-saint`). Own test run. Own PR. Own merge.
-- Execute at the clean seam (see Scheduling): nothing else in flight.
-- The GitHub repo rename (`savvy-cleanse-analysis` → per Marvin's instruction) is a
-  human step Marvin performs; the story updates in-repo references and the story
-  should flag the repo-rename hand-off explicitly.
+## Note
 
-## Tasks / Subtasks
-
-- [ ] Create branch `chore/R1-code-rename-saint` from a clean main (2.5 merged, Epic 3
-      not yet started).
-- [ ] `git mv savvycortex/ saint/` (preserve history). Confirm `dqa_engine.py` /
-      `drift_engine.py` filenames unchanged.
-- [ ] Update every `from savvycortex.*` / `import savvycortex` → `saint` (codebase-wide;
-      exclude archived docs and this story file).
-- [ ] Update `backend.api.app:app` entrypoint reference and any `python -m backend.*`
-      invocations / packaging metadata (pyproject, etc.) as affected.
-- [ ] Correct the landing-page `import savvyclean as sc` sample.
-- [ ] Full suite green (181 passed / 0 regressions). Run /security-review; resolve any
-      Critical/High.
-- [ ] Open PR. In the PR, flag the GitHub repo-rename hand-off for Marvin.
-
-## Dev Notes
-
-- This is a mechanical, high-blast-radius rename — hence `loop_eligible: false` and a
-  human merge. It touches every import; execute it as one atomic change at the clean
-  seam, not incrementally alongside feature work.
-- Documentation already says SAINT (canonical PRD, epics.md, sprint-status.yaml,
-  reconciliation, story files). This story removes the last remaining, deliberately
-  documented divergence — the code identifiers.
+This story's scope is intentionally left open pending a human decision (recorded 2026-07-11:
+the maintainer chose to re-file with corrected scope rather than execute now). The PRD
+Amendment 8 and reconciliation NAME MISMATCH note should be read in light of this correction —
+they describe the intent (documentation says SAINT; code will follow) but their specific
+package/filename references reflect the aspirational §7.3 layout, not the implemented tree.

--- a/_bmad-output/implementation-artifacts/prd-epic-reconciliation.md
+++ b/_bmad-output/implementation-artifacts/prd-epic-reconciliation.md
@@ -106,6 +106,12 @@ succeeds. Gate on quota, not speed.
 Documentation says SAINT; code says `savvycortex`. This is deliberate and time-boxed.
 Code rename is filed as Story R.1 (Task 8), executed after Story 2.5 merges and before
 Story 3.1 begins. This is not drift — drift is when nobody writes it down.
+CORRECTION (2026-07-11): R.1's original targets (a `savvycortex/` package, `from
+savvycortex.*` imports, a `dqa_engine.py` component, an `import savvyclean as sc` sample)
+reflect the PRD §7.3 ASPIRATIONAL layout and do NOT exist. In the real tree the package is
+`backend/`, the DQA engine is `data_quality.py`, and the FRONTEND is brand-named
+"SavvyClean". R.1 has been re-filed with corrected, deliberately-open scope — see
+R-1-code-rename-savvycortex-to-saint.md before scheduling it.
 Retired names: SavvyCortex (retired by this restructure) and the earlier retired name
 must not reappear in any documentation surface. Component filenames `dqa_engine.py` and
 `drift_engine.py` keep their current names permanently — the previously-held "cosmetic


### PR DESCRIPTION
R.1's filed scope (from the PRD §7.3 aspirational layout) didn't match the codebase: no `savvycortex/` package (it's `backend/`), no `savvycortex.*` imports, no `dqa_engine.py` (it's `data_quality.py`), and the frontend is brand-named **SavvyClean** (not SavvyCortex) across ~25 files. Re-filed R.1 with the real rename surface (backend product-name / frontend rebrand / repo rename / optional package rename) and deliberately-open scope, left `ready-for-dev`. **No rename executed.** Also added a correction pointer to the reconciliation NAME MISMATCH note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)