### PR TITLE
fix(frontend): repair broken logo references and update API docs domain

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -57,7 +57,7 @@ const Hero = () => {
               <div className="bg-white dark:bg-savvy-dark/90 p-4">
                 <div className="flex items-center mb-4 justify-center">
                   <img 
-                    src="/lovable-uploads/bce4ab85-e6f8-4810-9883-f33ee1cfb90d.png" 
+                    src="/lovable-uploads/1a5ff488-1ca2-4dda-8f25-3e165a31f539.png" 
                     alt="Savvy Analytics Logo" 
                     className="w-12 h-12"
                   />

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,7 +10,7 @@ const Footer = () => {
           <div>
             <div className="flex items-center gap-2">
               <img 
-                src="/lovable-uploads/bce4ab85-e6f8-4810-9883-f33ee1cfb90d.png" 
+                src="/lovable-uploads/1a5ff488-1ca2-4dda-8f25-3e165a31f539.png" 
                 alt="Savvy Analytics Logo" 
                 className="w-8 h-8"
               />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -120,7 +120,7 @@ const Dashboard = () => {
           </div>
           <div className="flex items-center">
             <img
-              src="/lovable-uploads/bce4ab85-e6f8-4810-9883-f33ee1cfb90d.png"
+              src="/lovable-uploads/1a5ff488-1ca2-4dda-8f25-3e165a31f539.png"
               alt="Savvy Analytics Logo"
               className="w-8 h-8 mr-2"
             />

--- a/src/pages/api-reference.tsx
+++ b/src/pages/api-reference.tsx
@@ -180,7 +180,7 @@ const APIReference = () => {
                   <Database className="h-8 w-8 text-savvy-blue mx-auto mb-3" />
                   <h3 className="font-semibold mb-2">Base URL</h3>
                   <code className="text-sm bg-muted px-2 py-1 rounded">
-                    https://api.savvyclean.com/v1
+                    https://api.savvyanalytics.info/v1
                   </code>
                 </CardContent>
               </Card>

--- a/src/pages/api.tsx
+++ b/src/pages/api.tsx
@@ -45,7 +45,7 @@ import requests
 
 # Upload dataset
 response = requests.post(
-    'https://api.savvyclean.com/v1/upload',
+    'https://api.savvyanalytics.info/v1/upload',
     files={'file': open('data.csv', 'rb')},
     headers={'Authorization': 'Bearer YOUR_API_KEY'}
 )
@@ -53,7 +53,7 @@ dataset_id = response.json()['dataset_id']
 
 # Run cleaning pipeline
 clean_response = requests.post(
-    f'https://api.savvyclean.com/v1/datasets/{dataset_id}/clean',
+    f'https://api.savvyanalytics.info/v1/datasets/{dataset_id}/clean',
     json={
         'operations': ['remove_duplicates', 'handle_missing', 'detect_outliers'],
         'options': {'missing_strategy': 'median'}
@@ -63,7 +63,7 @@ clean_response = requests.post(
 
 # Get cleaned data
 cleaned_data = requests.get(
-    f'https://api.savvyclean.com/v1/datasets/{dataset_id}/export',
+    f'https://api.savvyanalytics.info/v1/datasets/{dataset_id}/export',
     headers={'Authorization': 'Bearer YOUR_API_KEY'}
 )`;
 


### PR DESCRIPTION
Two client-facing defects found during the R.1 visual QA pass. Both were **pre-existing on `main`** — [#36](https://github.com/marvinmckinneyii0/savvy-cleanse-analysis/pull/36) changed no image-src or domain lines.

## 1. Broken logo — 4 refs pointing at a file that doesn't exist

`Hero.tsx`, `Footer.tsx`, and `Dashboard.tsx` all referenced `/lovable-uploads/bce4ab85-….png`, which is **not in `public/lovable-uploads/`**. They rendered as broken-image placeholders showing alt text. It failed *silently* in network logs because Vite's SPA fallback returns `200` with `index.html` for the missing path — so it looked fine to tooling and broken to users.

**Root cause:** `public/lovable-uploads/savvy-logo.png` is not an image. It's a **67-byte ASCII file** whose entire contents are the string `public/lovable-uploads/bce4ab85-….png` — the residue of a botched shell redirect (`echo path > file`) that **overwrote the original logo with its own filename**, destroying the asset.

All four refs now use `1a5ff488-….png` — the only real logo in the repo, and the one `Navbar` already used, so the mark is consistent sitewide.

**Verified in-browser:** every `<img>` decodes at `175×186` (`naturalWidth > 0`); the hero image was previously `0×0`. Zero broken images on `/`, `/api`, `/api-reference`, `/dashboard`.

> Note: the surviving asset is actually **JPEG data despite a `.png` extension**. Browsers content-sniff, so it renders correctly. Renaming it would require touching a 4th reference — deliberately left alone.

## 2. API docs domain — 4 occurrences

`api.savvyclean.com` → `api.savvyanalytics.info` in `api-reference.tsx` (the rendered **Base URL** card) and `api.tsx` (3 code-sample endpoints).

The retired **SavvyClean** brand was the most prominent element on a page otherwise branded SAINT — sitting directly under "Complete reference for all **SAINT** API endpoints." Uses the parent company's **real** domain (already shown sitewide as "Visit savvyanalytics.info") rather than inventing one. Closes the R.1 follow-up.

## Verification
- Frontend **18 tests pass**, production **build green**
- In-browser: `stale_domain: 0`, `broken_imgs: 0` across all checked routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)