### PR TITLE
Story 3.1: Classification Layer (remediation_class taxonomy)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -85,7 +85,7 @@ development_status:
   # PRD Phase 9 (self-healing) PULLED FORWARD — cleaning is the core thesis. Def: epic-3-cleaning-engine.md
   # =========================================================================
   epic-3: in-progress
-  3-1-classification-layer:                    { status: ready-for-dev, loop_eligible: false }  # M/Opus — remediation_class taxonomy; architecture-defining; story-filed 2026-07-12
+  3-1-classification-layer:                    { status: review, loop_eligible: false }  # M/Opus — remediation_class taxonomy; architecture-defining; story-filed 2026-07-12; implemented 2026-07-20 (220 passed/0 regressions, security-reviewed) — awaiting review/merge
   3-2-cleaning-engine-core:                    { status: backlog, loop_eligible: false }  # L/Opus — deterministic only
   3-3-healing-manifest:                        { status: backlog, loop_eligible: false }  # M/Opus — provenance-critical
   3-4-opt-in-gate-config:                      { status: backlog, loop_eligible: false }  # M/Opus — Tier 2 policy boundary; default OFF

--- a/backend/models/quality_report.py
+++ b/backend/models/quality_report.py
@@ -33,6 +33,35 @@ class DefectCategory(str, Enum):
     REFERENTIAL_INTEGRITY = "referential_integrity"
 
 
+class RemediationClass(str, Enum):
+    """Who owns the fix for a finding — the four-tier ownership model.
+
+    Set by :mod:`backend.pipeline.remediation_classifier`, which is the single
+    authoritative ``defect_type`` → class mapping. Consumed by the Cleaning
+    Engine (Story 3.2) and the Opt-in Gate (3.4) to decide what may be touched.
+
+    * ``AGENT_AUTONOMOUS`` — Tier 1. Agent fixes unconditionally
+      (whitespace/case/type normalization, exact duplicate rows, header
+      misalignment).
+    * ``HUMAN_POLICY_AGENT_EXECUTION`` — Tier 2. Human sets the policy once
+      (e.g. null-imputation method per column); the agent then executes it
+      indefinitely.
+    * ``HUMAN_ONLY`` — Tier 3. The agent detects and scores but NEVER acts.
+      Also the fail-safe default (see :class:`DataQualityDefect`).
+
+    There is deliberately **no Tier 4 value**. Tier 4 (Epic 11) is an opt-in
+    overlay permitting autonomous action on ``HUMAN_ONLY`` findings; the
+    ``remediation_class`` itself stays ``HUMAN_ONLY``.
+
+    These are internal identifiers. Client-facing surfaces use descriptive
+    names (Story 3.9) and must never expose tier numbers.
+    """
+
+    AGENT_AUTONOMOUS = "agent_autonomous"
+    HUMAN_POLICY_AGENT_EXECUTION = "human_policy_agent_execution"
+    HUMAN_ONLY = "human_only"
+
+
 class DataQualityDefect(BaseModel):
     """A single data-quality finding."""
 
@@ -44,6 +73,13 @@ class DataQualityDefect(BaseModel):
     percentage: float
     details: str
     recommended_action: str
+    # Defaulted for two independent reasons, both load-bearing:
+    #   1. Backward compatibility — Epic 1/2 findings and any serialized report
+    #      predating this field still validate.
+    #   2. Fail-safe — an unmapped or future defect_type must never be eligible
+    #      for autonomous cleaning, so the default is the most conservative
+    #      class. Never relax this default.
+    remediation_class: RemediationClass = RemediationClass.HUMAN_ONLY
 
 
 class ColumnProfile(BaseModel):

--- a/backend/pipeline/data_quality.py
+++ b/backend/pipeline/data_quality.py
@@ -25,6 +25,7 @@ from backend.models.quality_report import (
     DefectCategory,
     Severity,
 )
+from backend.pipeline.remediation_classifier import classify_defects
 
 _NON_NEGATIVE_KEYWORDS = ("revenue", "quantity", "count", "price", "amount", "volume")
 
@@ -477,6 +478,12 @@ class DataQualityAssessor:
         all_defects.extend(self._check_uniqueness(df))
         all_defects.extend(self._check_statistical_red_flags(df))
         all_defects.extend(self._check_referential_integrity(df))
+
+        # Stamp ownership on every finding (Story 3.1). Applied once, here,
+        # so no detector has to remember to set it — and so an unmapped
+        # defect_type fails safe to HUMAN_ONLY rather than going unstamped.
+        # Purely additive: severity, scoring and halt logic below are unchanged.
+        all_defects = classify_defects(all_defects)
 
         # Overall severity
         if not all_defects:

--- a/backend/pipeline/remediation_classifier.py
+++ b/backend/pipeline/remediation_classifier.py
@@ -1,0 +1,107 @@
+"""Remediation Classifier — assigns ownership of every DQA finding (Story 3.1).
+
+Stamps each :class:`DataQualityDefect` with the
+:class:`~backend.models.quality_report.RemediationClass` that declares *who may
+fix it*: the agent unconditionally (Tier 1), the agent under a human-set policy
+(Tier 2), or a human only (Tier 3). The Cleaning Engine (Story 3.2) and Opt-in
+Gate (3.4) act on this tag — so a mis-classification here is the mechanism by
+which a human-only finding could be auto-modified. That is the load-bearing
+invariant of Epic 3.
+
+Two design rules protect it:
+
+1. **Keyed on ``defect_type``, never on ``category``.** Categories split across
+   tiers in the spec: exact duplicates are Tier 1 while near-duplicates are
+   Tier 3, and header misalignment is Tier 1 while an unreadable structure is
+   Tier 3 — yet each pair shares a ``DefectCategory``. Keying on the narrower
+   ``defect_type`` means a future ``near_duplicate`` type cannot silently
+   inherit ``duplicate_rows``'s autonomous class.
+2. **Unmapped ⇒ ``HUMAN_ONLY``.** Anything absent from the table below — a new
+   detector, a typo, a renamed type — falls back to the most conservative
+   class. Adding a detector can therefore never *widen* what the agent may
+   touch; that requires a deliberate edit here.
+
+Pure and side-effect-free: no I/O, no logging, no config. Architecture
+compliance (architecture.md §745): lives in ``backend/pipeline/``, imports only
+from ``models/``, never from ``api/`` or legacy modules.
+"""
+
+from __future__ import annotations
+
+from backend.models.quality_report import (
+    DataQualityDefect,
+    DataQualityReport,
+    RemediationClass,
+)
+
+# ---------------------------------------------------------------------------
+# The authoritative mapping (Story 3.1, schema-extensions-spec.md §1).
+#
+# Every defect_type emitted by DataQualityAssessor appears here exactly once.
+# A test asserts this table stays in sync with the assessor — if you add a
+# detector, add its defect_type here, or it silently classifies HUMAN_ONLY.
+# ---------------------------------------------------------------------------
+_DEFECT_TYPE_TO_CLASS: dict[str, RemediationClass] = {
+    # --- Tier 1: agent fixes unconditionally -------------------------------
+    # Mechanical, reversible, no domain judgement required.
+    "mixed_types": RemediationClass.AGENT_AUTONOMOUS,
+    "column_naming": RemediationClass.AGENT_AUTONOMOUS,
+    "case_inconsistency": RemediationClass.AGENT_AUTONOMOUS,
+    "duplicate_rows": RemediationClass.AGENT_AUTONOMOUS,
+    # --- Tier 2: human sets policy once, agent executes --------------------
+    # A defensible default exists, but the choice belongs to the client.
+    "null_values": RemediationClass.HUMAN_POLICY_AGENT_EXECUTION,
+    "non_unique_id": RemediationClass.HUMAN_POLICY_AGENT_EXECUTION,
+    # --- Tier 3: agent detects and scores, never acts ----------------------
+    "zero_variance": RemediationClass.HUMAN_ONLY,
+    "extreme_outliers": RemediationClass.HUMAN_ONLY,
+    "extreme_cardinality": RemediationClass.HUMAN_ONLY,
+    # negative_values: a domain-plausibility flag, not a formatting nit — it
+    # fires only on columns whose name implies non-negativity (revenue, price,
+    # quantity...). Whether a negative is an error, a refund, or legitimate is
+    # a business question. Never auto-fix.
+    "negative_values": RemediationClass.HUMAN_ONLY,
+    # infinite_values: mechanically coercible to null, but inf usually signals
+    # an upstream computation error a human should see rather than have
+    # silently patched.
+    "infinite_values": RemediationClass.HUMAN_ONLY,
+    # duplicate_measurement: a *column-pair* correlation signal (Pearson
+    # |corr| > 0.99) — a redundant-column hint, NOT a duplicate-record finding
+    # (that is `duplicate_rows`, above, and is Tier 1). Remediation means
+    # dropping or merging one of two correlated columns; which one is
+    # canonical cannot be determined mechanically, and the change is
+    # irreversible. Tier 3.
+    "duplicate_measurement": RemediationClass.HUMAN_ONLY,
+}
+
+
+def classify(defect_type: str) -> RemediationClass:
+    """Return the remediation class owning ``defect_type``.
+
+    Unmapped types return :attr:`RemediationClass.HUMAN_ONLY` — the fail-safe.
+    Pure: same input always yields the same output, with no side effects.
+    """
+    return _DEFECT_TYPE_TO_CLASS.get(defect_type, RemediationClass.HUMAN_ONLY)
+
+
+def classify_defect(defect: DataQualityDefect) -> DataQualityDefect:
+    """Return a copy of ``defect`` with ``remediation_class`` set.
+
+    Does not mutate the input. Idempotent: the class is derived solely from
+    ``defect_type``, so re-classifying an already-stamped defect is a no-op.
+    """
+    return defect.model_copy(update={"remediation_class": classify(defect.defect_type)})
+
+
+def classify_defects(defects: list[DataQualityDefect]) -> list[DataQualityDefect]:
+    """Stamp every defect in ``defects``, returning a new list."""
+    return [classify_defect(defect) for defect in defects]
+
+
+def classify_report(report: DataQualityReport) -> DataQualityReport:
+    """Return a copy of ``report`` with every defect stamped.
+
+    Convenience for callers holding a whole report (e.g. re-classifying a
+    persisted one). The assessor stamps its defect list directly instead.
+    """
+    return report.model_copy(update={"defects": classify_defects(report.defects)})

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -17,6 +17,7 @@ from backend.models.quality_report import (
     DataQualityDefect,
     DataQualityReport,
     DefectCategory,
+    RemediationClass,
     Severity,
 )
 
@@ -73,6 +74,64 @@ class TestDataQualityDefect:
         data = defect.model_dump()
         restored = DataQualityDefect.model_validate(data)
         assert restored == defect
+
+    def test_remediation_class_defaults_to_human_only(self) -> None:
+        """Story 3.1 AC 2 — omitting the field must fail safe, never autonomous."""
+        defect = DataQualityDefect(
+            defect_type="null_values",
+            category=DefectCategory.COMPLETENESS,
+            severity=Severity.HIGH,
+            affected_columns=["revenue"],
+            count=1,
+            percentage=1.0,
+            details="d",
+            recommended_action="a",
+        )
+        assert defect.remediation_class == RemediationClass.HUMAN_ONLY
+
+    def test_legacy_payload_without_remediation_class_validates(self) -> None:
+        """Story 3.1 AC 1 — reports serialized before Epic 3 still load."""
+        legacy = {
+            "defect_type": "duplicate_rows",
+            "category": "uniqueness",
+            "severity": "low",
+            "affected_columns": [],
+            "count": 2,
+            "percentage": 4.0,
+            "details": "4% duplicate rows",
+            "recommended_action": "Deduplicate",
+        }
+        restored = DataQualityDefect.model_validate(legacy)
+        assert restored.remediation_class == RemediationClass.HUMAN_ONLY
+
+    def test_explicit_remediation_class_is_preserved(self) -> None:
+        defect = DataQualityDefect(
+            defect_type="duplicate_rows",
+            category=DefectCategory.UNIQUENESS,
+            severity=Severity.LOW,
+            affected_columns=[],
+            count=2,
+            percentage=4.0,
+            details="d",
+            recommended_action="a",
+            remediation_class=RemediationClass.AGENT_AUTONOMOUS,
+        )
+        assert defect.remediation_class == RemediationClass.AGENT_AUTONOMOUS
+        assert defect.model_dump()["remediation_class"] == "agent_autonomous"
+
+
+class TestRemediationClass:
+    def test_exactly_three_values(self) -> None:
+        """Tier 4 (Epic 11) is an opt-in overlay, not a fourth class."""
+        assert len(RemediationClass) == 3
+
+    def test_values(self) -> None:
+        assert RemediationClass.AGENT_AUTONOMOUS.value == "agent_autonomous"
+        assert (
+            RemediationClass.HUMAN_POLICY_AGENT_EXECUTION.value
+            == "human_policy_agent_execution"
+        )
+        assert RemediationClass.HUMAN_ONLY.value == "human_only"
 
 
 class TestColumnProfile:

--- a/backend/tests/test_remediation_classifier.py
+++ b/backend/tests/test_remediation_classifier.py
@@ -1,0 +1,250 @@
+"""Tests for the Remediation Classifier (Story 3.1).
+
+The mapping these tests guard is load-bearing: the Cleaning Engine (3.2) and
+Opt-in Gate (3.4) decide what they may modify from ``remediation_class``, so a
+finding mis-tiered toward autonomy is how human-only data gets auto-changed.
+The suite therefore pins every mapping explicitly rather than asserting shapes,
+and includes a drift guard against the assessor (see
+:class:`TestMappingCoversAssessor`).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from backend.models.quality_report import (
+    DataQualityDefect,
+    DefectCategory,
+    RemediationClass,
+    Severity,
+)
+from backend.pipeline.data_quality import DataQualityAssessor
+from backend.pipeline.remediation_classifier import (
+    _DEFECT_TYPE_TO_CLASS,
+    classify,
+    classify_defect,
+    classify_defects,
+    classify_report,
+)
+
+# Every defect_type the assessor emits today, with the tier it was assigned in
+# the Story 3.1 spec. Written out longhand — deriving it from the mapping under
+# test would make the test tautological.
+EXPECTED: list[tuple[str, RemediationClass]] = [
+    # Tier 1 — agent autonomous
+    ("mixed_types", RemediationClass.AGENT_AUTONOMOUS),
+    ("column_naming", RemediationClass.AGENT_AUTONOMOUS),
+    ("case_inconsistency", RemediationClass.AGENT_AUTONOMOUS),
+    ("duplicate_rows", RemediationClass.AGENT_AUTONOMOUS),
+    # Tier 2 — human sets policy, agent executes
+    ("null_values", RemediationClass.HUMAN_POLICY_AGENT_EXECUTION),
+    ("non_unique_id", RemediationClass.HUMAN_POLICY_AGENT_EXECUTION),
+    # Tier 3 — human only
+    ("zero_variance", RemediationClass.HUMAN_ONLY),
+    ("extreme_outliers", RemediationClass.HUMAN_ONLY),
+    ("extreme_cardinality", RemediationClass.HUMAN_ONLY),
+    ("negative_values", RemediationClass.HUMAN_ONLY),
+    ("infinite_values", RemediationClass.HUMAN_ONLY),
+    ("duplicate_measurement", RemediationClass.HUMAN_ONLY),
+]
+
+
+def _defect(defect_type: str, **overrides: object) -> DataQualityDefect:
+    """Build a minimal defect; only ``defect_type`` affects classification."""
+    payload: dict[str, object] = {
+        "defect_type": defect_type,
+        "category": DefectCategory.CONSISTENCY,
+        "severity": Severity.LOW,
+        "affected_columns": ["col_a"],
+        "count": 1,
+        "percentage": 1.0,
+        "details": "synthetic finding",
+        "recommended_action": "none",
+    }
+    payload.update(overrides)
+    return DataQualityDefect(**payload)  # type: ignore[arg-type]
+
+
+class TestRemediationClassEnum:
+    def test_exactly_three_values(self) -> None:
+        """Tier 4 is an opt-in overlay (Epic 11), NOT a fourth class."""
+        assert len(RemediationClass) == 3
+
+    def test_values(self) -> None:
+        assert RemediationClass.AGENT_AUTONOMOUS.value == "agent_autonomous"
+        assert (
+            RemediationClass.HUMAN_POLICY_AGENT_EXECUTION.value
+            == "human_policy_agent_execution"
+        )
+        assert RemediationClass.HUMAN_ONLY.value == "human_only"
+
+
+class TestClassify:
+    @pytest.mark.parametrize(("defect_type", "expected"), EXPECTED)
+    def test_each_defect_type(
+        self, defect_type: str, expected: RemediationClass
+    ) -> None:
+        assert classify(defect_type) == expected
+
+    def test_every_current_defect_type_is_covered(self) -> None:
+        assert set(_DEFECT_TYPE_TO_CLASS) == {d for d, _ in EXPECTED}
+
+    @pytest.mark.parametrize(
+        "unknown",
+        [
+            "",
+            "not_a_real_defect",
+            "near_duplicate",  # plausible future Tier-3 detector
+            "DUPLICATE_ROWS",  # case variance must not match
+            "duplicate_rows ",  # whitespace variance must not match
+        ],
+    )
+    def test_unmapped_defect_type_fails_safe(self, unknown: str) -> None:
+        """The fail-safe: anything unrecognised is never agent-actionable."""
+        assert classify(unknown) == RemediationClass.HUMAN_ONLY
+
+    def test_no_tier1_or_tier2_leaks_via_default(self) -> None:
+        """Autonomy is only ever granted by an explicit table entry."""
+        autonomous = {
+            d
+            for d, c in _DEFECT_TYPE_TO_CLASS.items()
+            if c != RemediationClass.HUMAN_ONLY
+        }
+        assert autonomous == {
+            "mixed_types",
+            "column_naming",
+            "case_inconsistency",
+            "duplicate_rows",
+            "null_values",
+            "non_unique_id",
+        }
+
+    def test_duplicate_rows_and_duplicate_measurement_differ(self) -> None:
+        """Similar names, unrelated findings — must not be conflated.
+
+        ``duplicate_rows`` is exact duplicate records (Tier 1).
+        ``duplicate_measurement`` is a column-pair correlation signal whose
+        remediation is an irreversible schema decision (Tier 3).
+        """
+        assert classify("duplicate_rows") == RemediationClass.AGENT_AUTONOMOUS
+        assert classify("duplicate_measurement") == RemediationClass.HUMAN_ONLY
+
+
+class TestClassifyDefect:
+    def test_stamps_the_class(self) -> None:
+        stamped = classify_defect(_defect("duplicate_rows"))
+        assert stamped.remediation_class == RemediationClass.AGENT_AUTONOMOUS
+
+    def test_does_not_mutate_input(self) -> None:
+        original = _defect("duplicate_rows")
+        classify_defect(original)
+        assert original.remediation_class == RemediationClass.HUMAN_ONLY
+
+    def test_preserves_all_other_fields(self) -> None:
+        original = _defect("null_values", count=42, details="original detail")
+        stamped = classify_defect(original)
+        assert stamped.model_dump(exclude={"remediation_class"}) == original.model_dump(
+            exclude={"remediation_class"}
+        )
+
+    def test_idempotent(self) -> None:
+        once = classify_defect(_defect("extreme_outliers"))
+        twice = classify_defect(once)
+        assert once == twice
+
+    def test_corrects_a_wrongly_stamped_defect(self) -> None:
+        """Class derives from defect_type, so a bad prior value is overwritten."""
+        mis_stamped = _defect(
+            "extreme_outliers",
+            remediation_class=RemediationClass.AGENT_AUTONOMOUS,
+        )
+        assert classify_defect(mis_stamped).remediation_class == (
+            RemediationClass.HUMAN_ONLY
+        )
+
+
+class TestClassifyCollections:
+    def test_classify_defects_stamps_all(self) -> None:
+        stamped = classify_defects([_defect(d) for d, _ in EXPECTED])
+        assert [s.remediation_class for s in stamped] == [c for _, c in EXPECTED]
+
+    def test_classify_defects_empty(self) -> None:
+        assert classify_defects([]) == []
+
+    def test_classify_report_stamps_every_defect(self) -> None:
+        assessor = DataQualityAssessor()
+        df = pd.DataFrame({"revenue": [1.0, 1.0, None, 5000.0], "name": ["a", "A", "b", "b"]})
+        report = assessor.assess_quality(df, "run-classify-report").quality_report
+        assert report is not None
+
+        rebuilt = classify_report(report)
+        assert len(rebuilt.defects) == len(report.defects)
+        for defect in rebuilt.defects:
+            assert defect.remediation_class == classify(defect.defect_type)
+
+
+class TestAssessorStampsFindings:
+    """AC 6 — the assessor's output is stamped, not just the classifier's."""
+
+    def test_every_defect_in_a_real_report_is_stamped(self) -> None:
+        assessor = DataQualityAssessor()
+        df = pd.DataFrame(
+            {
+                "revenue": [100.0, 100.0, None, -50.0],
+                "Name": ["alpha", "ALPHA", "beta", "beta"],
+                "flat": [7, 7, 7, 7],
+            }
+        )
+        report = assessor.assess_quality(df, "run-stamped").quality_report
+
+        assert report is not None
+        assert report.defects, "fixture should trigger at least one finding"
+        for defect in report.defects:
+            assert defect.remediation_class == classify(defect.defect_type), (
+                f"{defect.defect_type} was not stamped correctly"
+            )
+
+    def test_clean_frame_produces_no_unstamped_defects(self) -> None:
+        assessor = DataQualityAssessor()
+        df = pd.DataFrame({"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"]})
+        report = assessor.assess_quality(df, "run-clean").quality_report
+
+        assert report is not None
+        for defect in report.defects:
+            assert defect.remediation_class in set(RemediationClass)
+
+
+class TestMappingCoversAssessor:
+    """Drift guard: adding a detector must not silently bypass the mapping.
+
+    A new ``defect_type`` that nobody adds to the table would classify
+    ``HUMAN_ONLY`` — safe, but silently un-cleanable and easy to miss. This
+    reads the assessor's source and fails loudly instead.
+    """
+
+    def test_no_assessor_defect_type_is_missing_from_the_mapping(self) -> None:
+        source = Path("backend/pipeline/data_quality.py").read_text(encoding="utf-8")
+        emitted = set(re.findall(r'defect_type="([a-z_]+)"', source))
+
+        assert emitted, "failed to parse any defect_type from the assessor"
+
+        missing = emitted - set(_DEFECT_TYPE_TO_CLASS)
+        assert not missing, (
+            f"defect_type(s) {sorted(missing)} are emitted by DataQualityAssessor "
+            "but absent from _DEFECT_TYPE_TO_CLASS. Add them to the mapping in "
+            "backend/pipeline/remediation_classifier.py with a deliberate tier."
+        )
+
+    def test_mapping_has_no_entries_for_nonexistent_defect_types(self) -> None:
+        source = Path("backend/pipeline/data_quality.py").read_text(encoding="utf-8")
+        emitted = set(re.findall(r'defect_type="([a-z_]+)"', source))
+
+        stale = set(_DEFECT_TYPE_TO_CLASS) - emitted
+        assert not stale, (
+            f"mapping entries {sorted(stale)} no longer correspond to any "
+            "defect_type emitted by DataQualityAssessor"
+        )


### PR DESCRIPTION
Implements [Story 3.1](https://github.com/marvinmckinneyii0/savvy-cleanse-analysis/blob/main/_bmad-output/implementation-artifacts/3-1-classification-layer.md), the first story of Epic 3 and the foundation the rest of the cleaning epic gates on.

Every DQA finding is now stamped with the class declaring **who may fix it**, so the Cleaning Engine (3.2) and Opt-in Gate (3.4) can act only on findings they're permitted to touch. **Classification only** — nothing is cleaned, imputed, deduped, or modified.

## The load-bearing property

Epic 3's invariant is *Tier-3 findings are never auto-touched*. Two mechanisms enforce it:

1. **Fail-safe default.** `remediation_class` defaults to `human_only`. An unmapped `defect_type` — a new detector, a typo, a rename — is never eligible for autonomous cleaning. Adding a detector can only ever *narrow* what the agent may touch; widening it requires a deliberate edit to the mapping.
2. **Keyed on `defect_type`, not `category`.** Categories split across tiers: exact duplicates are Tier 1 while near-duplicates are Tier 3; header misalignment is Tier 1 while an unreadable structure is Tier 3 — yet each pair shares a `DefectCategory`. Keying on the narrower field means a future `near_duplicate` can't silently inherit `duplicate_rows`'s autonomous class.

## Changes

| File | What |
|---|---|
| `models/quality_report.py` | `RemediationClass(str, Enum)` (3 values — **no** Tier-4 value; Tier 4 is an Epic-11 overlay on `human_only`) + defaulted field |
| `pipeline/remediation_classifier.py` *(new)* | Single authoritative mapping, all 12 `defect_type`s. Pure — no I/O, no logging. Non-mutating and idempotent |
| `pipeline/data_quality.py` | One call in `assess_quality` stamps all findings centrally. Detection, severity, scoring, halt logic **unchanged** |

The default is doing double duty: backward compatibility (Epic 1/2 findings and previously-serialized reports still validate) *and* the fail-safe.

## Tier-3 decisions locked (were open in the spec)

- **`negative_values`** — fires only on columns whose name implies non-negativity. Whether a negative is an error, a refund, or legitimate is a business question.
- **`infinite_values`** — mechanically coercible, but `inf` usually signals an upstream computation error a human should see rather than have silently patched.
- **`duplicate_measurement`** — a **column-pair** correlation signal (`|corr| > 0.99`), *not* duplicate records (that's `duplicate_rows`, Tier 1). Remediation means dropping/merging one of two correlated columns — irreversible, and which is canonical isn't mechanically decidable.

## Verification

- **220 passed / 1 skipped** — up from the 181 baseline, **0 regressions**
- Coverage: every `defect_type`; the `human_only` fail-safe for unmapped, case-variant and whitespace-variant inputs; legacy payloads lacking the field; non-mutation, idempotency, and correction of a wrongly-stamped defect
- **Drift guard:** a test parses the assessor's source and fails loudly if a new `defect_type` is emitted without a deliberate tier — the fail-safe would otherwise hide it as silently un-cleanable
- **End-to-end on real data:** a 7-finding frame classified as expected — `negative_values` and `duplicate_measurement` both landed in `human_only`, `duplicate_rows`/`case_inconsistency` in `agent_autonomous`, `null_values` in `human_policy_agent_execution`. No unstamped findings
- `/security-review`: **no findings**

`sprint-status.yaml`: `3-1` → `review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)