### PR TITLE
Story 3.2: Cleaning Engine Core (deterministic, Tier-1 autonomous only)

### DIFF
--- a/_bmad-output/implementation-artifacts/3-2-cleaning-engine-core.md
+++ b/_bmad-output/implementation-artifacts/3-2-cleaning-engine-core.md
@@ -75,6 +75,24 @@ This story builds the **engine and its action record** — nothing else. Explici
 - [x] **Task 6 — Verify + security (AC: 8, 9)**
   - [x] Full backend suite: 268 passed / 1 skipped / 0 regressions. `/security-review`: no Critical/High (no external attack surface — pure in-memory transforms).
 
+### Review Findings
+
+Reviewed by Sonnet (dev was Opus) via `bmad-code-review` — 3 parallel layers (Blind Hunter, Edge Case Hunter, Acceptance Auditor) against PR #42's branch diff.
+
+- [x] [Review][Patch] Header normalization renamed every column in the frame, not just the ones with a flagged `column_naming` finding — violated AC2/AC3 Tier-1-only scoping (a non-flagged, no-defect column could be silently re-slugged) [backend/pipeline/cleaning_engine.py:355, backend/pipeline/cleaning_primitives.py:836] — fixed: `normalize_column_names` gained a `targets` param; untouched columns are reserved in a first pass so renames de-collide against them without ever touching them.
+- [x] [Review][Patch] `_normalize_headers` call site not wrapped in try/except unlike the per-finding loop — an unexpected exception there would abort `clean()` instead of degrading to a FAILED action [backend/pipeline/cleaning_engine.py:120] — fixed: wrapped identically to the per-finding loop.
+- [x] [Review][Patch] `dominant_python_type` tie-break relied on `Series.value_counts()` iteration/hash order — could pick a different "dominant" type across process runs on an exact count tie, violating AC6 "no iteration-order dependence" [backend/pipeline/cleaning_primitives.py:688] — fixed: counts via `Counter`, ties broken deterministically on `(module, qualname)`.
+- [x] [Review][Patch] `_failed_action` hardcoded `scope=CleaningScope.COLUMN` regardless of which operation actually failed (e.g. a failed dedup was recorded as column-scoped, contradicting `CleaningScope`'s own semantics) [backend/pipeline/cleaning_engine.py:602] — fixed: `_SCOPE_BY_OPERATION` lookup; also truncated `error` message to 200 chars as defense-in-depth against embedding raw cell values.
+- [x] [Review][Patch] `impute_nulls` called `.mean()`/`.median()` on a non-numeric column with only pandas' own (less clear) TypeError as a guard [backend/pipeline/cleaning_primitives.py:868] — fixed: explicit `ValueError` with a clear message, matching the primitive's own "fail loudly rather than guess" stated intent.
+- [x] [Review][Defer] Only `affected_columns[0]` consulted for `case_inconsistency`/`mixed_types` — a multi-column finding would be under-fixed — deferred, not reachable: `data_quality.py` always emits single-element `affected_columns` for these types.
+- [x] [Review][Defer] Deduplication dispatched per-finding though it's a whole-table op — a second `duplicate_rows` finding would produce a confusing "removed 0 rows" action — deferred, not reachable: the assessor emits at most one `duplicate_rows` defect per run.
+- [x] [Review][Defer] `normalize_column_names` mapping collisions / primitive breakage on duplicate column labels — deferred, not reachable: `pd.read_csv` (the only ingestion path) disambiguates duplicate headers upstream.
+- [x] [Review][Defer] `df.copy(deep=True)` doesn't recursively deep-copy nested mutable objects in object-dtype cells — deferred, theoretical: CSV-sourced data never carries nested list/dict cells.
+
+Dismissed as noise/false-positive: "`cleaning_action_applied` never emitted" (verified present in the actual source — an artifact of a condensed diff given to one review layer), "independent second guard is unreachable dead code" (this is exactly what AC2 requires as defense-in-depth for future/direct callers), "case tie-break can pick an ALL-CAPS canonical" (matches AC3's literal "ties break lexicographically" spec), "`_skipped_action` leaves before/after state empty" (cosmetic), "`_cell_changed` raises on array-like cells" (unreachable via CSV-sourced data), "`actions` list mixes SKIPPED entries" and "`target_columns` vs spec's `affected_columns` naming" (both pre-disclosed, intentional deviations in Completion Notes below).
+
+Post-fix verification: 11 new tests added (78 total in `test_cleaning_engine.py` + `test_models.py`, up from 67); full backend suite **279 passed / 1 skipped / 0 regressions** (up from 268).
+
 ## Dev Notes
 
 ### Operation specs (deterministic, keyed on `defect_type`)

--- a/_bmad-output/implementation-artifacts/3-2-cleaning-engine-core.md
+++ b/_bmad-output/implementation-artifacts/3-2-cleaning-engine-core.md
@@ -1,6 +1,6 @@
 # Story 3.2: Cleaning Engine Core (deterministic only)
 
-Status: ready-for-dev
+Status: review
 
 Sizing: L · Model: Opus · loop_eligible: false
 <!-- Opus + loop_eligible:false because this is the first code path in the product that
@@ -60,20 +60,20 @@ This story builds the **engine and its action record** — nothing else. Explici
 
 ## Tasks / Subtasks
 
-- [ ] **Task 0 — Confirm prerequisite (AC: 2)**
-  - [ ] Verify PR #39 (Story 3.1) is merged to main; `RemediationClass` and `remediation_classifier.classify` importable. HALT if not.
-- [ ] **Task 1 — Models (AC: 5)**
-  - [ ] `backend/models/cleaning_result.py`: `CleaningOperation(str, Enum)` (five values), `CleaningAction`, `CleaningResult` (Pydantic, PascalCase noun pattern per `quality_report.py`).
-- [ ] **Task 2 — Error type (AC: 7)**
-  - [ ] Add `CleaningEngineError(PipelineStageError)` to `backend/errors/exceptions.py`.
-- [ ] **Task 3 — Primitives (AC: 3, 4)**
-  - [ ] Pure functions: `normalize_whitespace`, `coerce_column_type` (incl. ISO-8601 date standardization), `drop_exact_duplicates`, `normalize_case`, `normalize_column_names`, `impute_nulls` (method required).
-- [ ] **Task 4 — Engine (AC: 1, 2, 5, 6, 7)**
-  - [ ] `CleaningEngine.clean(df, quality_report, pipeline_run_id) -> tuple[pd.DataFrame, CleaningResult]`: deep-copy at entry; filter to `AGENT_AUTONOMOUS`; registry `defect_type → operation` (four entries); fail-closed private dispatch; stable operation order (registry order, then column order); structlog events.
-- [ ] **Task 5 — Tests (AC: 8)**
-  - [ ] Dirty fixture in `conftest.py`; unit + integration tests per AC 8; full suite green, 0 regressions.
-- [ ] **Task 6 — Verify + security (AC: 8, 9)**
-  - [ ] Full backend suite; `/security-review`; resolve Critical/High.
+- [x] **Task 0 — Confirm prerequisite (AC: 2)**
+  - [x] Verify PR #39 (Story 3.1) is merged to main; `RemediationClass` and `remediation_classifier.classify` importable. HALT if not. → confirmed on main; `classify('unknown')==human_only`.
+- [x] **Task 1 — Models (AC: 5)**
+  - [x] `backend/models/cleaning_result.py`: `CleaningOperation(str, Enum)`, `CleaningAction`, `CleaningResult` (Pydantic). Added `CleaningScope`, `CleaningStatus`, and a `NO_OP` operation sentinel for skipped records.
+- [x] **Task 2 — Error type (AC: 7)**
+  - [x] Added `CleaningEngineError(PipelineStageError)` to `backend/errors/exceptions.py`.
+- [x] **Task 3 — Primitives (AC: 3, 4)**
+  - [x] Pure functions in `backend/pipeline/cleaning_primitives.py`: `strip_whitespace`, `coerce_column_type` (incl. ISO-8601 date standardization), `drop_exact_duplicates`, `normalize_case`, `normalize_column_names`, `impute_nulls` (method required, no default).
+- [x] **Task 4 — Engine (AC: 1, 2, 5, 6, 7)**
+  - [x] `CleaningEngine.clean(df, quality_report, pipeline_run_id) -> tuple[pd.DataFrame, CleaningResult]`: deep-copy at entry; filter to `AGENT_AUTONOMOUS`; registry `defect_type → operation` (four entries); fail-closed private dispatch (`_apply_operation` + `_normalize_headers` re-check + raise); deterministic processing order (coercion → case → dedup → header-last); structlog events (counts/columns only).
+- [x] **Task 5 — Tests (AC: 8)**
+  - [x] `cleaning_dirty_df` fixture in `conftest.py`; `test_cleaning_engine.py` (unit + integration) + cleaning-model tests in `test_models.py`. Full suite green, 0 regressions.
+- [x] **Task 6 — Verify + security (AC: 8, 9)**
+  - [x] Full backend suite: 268 passed / 1 skipped / 0 regressions. `/security-review`: no Critical/High (no external attack surface — pure in-memory transforms).
 
 ## Dev Notes
 
@@ -135,8 +135,38 @@ This story builds the **engine and its action record** — nothing else. Explici
 
 ### Agent Model Used
 
+Claude Opus 4.8 (high effort) — first data-mutating path, treated as architecture-critical per story sizing.
+
 ### Debug Log References
+
+- Assessor emission verified against `cleaning_dirty_df` before writing assertions: 4 Tier-1 (`mixed_types`/code, `column_naming`/amount#, `case_inconsistency`/region, `duplicate_rows`), 1 Tier-2 (`null_values`/quantity), 1 Tier-3 (`negative_values`/quantity); not halted.
+- Full suite: 268 passed / 1 skipped (optional `anthropic` SDK) / 0 regressions. New tests: 67 (55 in `test_cleaning_engine.py`, 12 model tests in `test_models.py`). Frontend unaffected: vitest 18/18, vite build OK.
 
 ### Completion Notes List
 
+- **Module split:** pure `cleaning_primitives.py` (mechanics) + `cleaning_engine.py` (dispatch/policy). Lets Story 3.4 import `impute_nulls` without pulling in the autonomous engine.
+- **Fail-closed twice:** public `clean()` filters to `AGENT_AUTONOMOUS`; private `_apply_operation`/`_normalize_headers` independently re-check and raise `CleaningEngineError`. No flag widens this.
+- **Deterministic order:** coercion → case → dedup → header-last (header rename last so column-name-keyed ops resolve against original names). Documented in the engine.
+- **Non-destructive coercion:** uncoercible values are preserved and counted (`uncoerced`), never nulled. Confirmed by test.
+- **Imputation boundary:** `impute_nulls(df, column, method)` — `method` mandatory (no default arg), not in the operation registry, unreachable from the autonomous path. A mis-stamped `null_values` finding produces a SKIPPED/`NO_OP` record and zero data change.
+- **Provenance:** `CleaningAction`/`CleaningResult` carry defect_type, operation, scope, target, before/after state, rows/values changed, value_mapping, deterministic rule, remediation_class, status, and safe error — the single source for Story 3.3's manifest. No parallel manifest format.
+- **Added `NO_OP` operation + `SKIPPED`/`FAILED` statuses** beyond the story's minimal enum list to give the manifest honest records for the fail-closed and error paths.
+- **Legacy `backend/cleaner.py`:** left behaviorally untouched; added a STATUS header marking it legacy (delegates to legacy `advanced_pipeline`) and pointing to the new engine. Not imported, extended, or deleted.
+- **Not wired to the orchestrator** — deferred to Story 3.4 (opt-in gate; cleaning stays default-off).
+- **Deviations from spec:** none material. Additive-only refinements: the `NO_OP`/`SKIPPED`/`FAILED` records and the `CleaningScope` field (not enumerated in the story's minimal model list) improve manifest fidelity without changing the contract.
+
 ### File List
+
+- `backend/models/cleaning_result.py` (new) — `CleaningOperation`, `CleaningScope`, `CleaningStatus`, `CleaningAction`, `CleaningResult`.
+- `backend/pipeline/cleaning_primitives.py` (new) — pure deterministic primitives incl. policy-less `impute_nulls`.
+- `backend/pipeline/cleaning_engine.py` (new) — `CleaningEngine` (Tier-1-only, fail-closed, working-copy).
+- `backend/errors/exceptions.py` (modified) — added `CleaningEngineError(PipelineStageError)`.
+- `backend/cleaner.py` (modified) — legacy STATUS header only (no behavior change).
+- `backend/tests/conftest.py` (modified) — added `cleaning_dirty_df` fixture.
+- `backend/tests/test_cleaning_engine.py` (new) — engine + primitives + integration tests.
+- `backend/tests/test_models.py` (modified) — cleaning-model tests.
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified) — 3-2 → in-progress → review.
+
+## Change Log
+
+- 2026-07-20: Implemented deterministic Cleaning Engine core (Story 3.2). Four Tier-1 autonomous operations (dedup, case normalization, type coercion, header normalization) on a working copy; policy-less imputation primitive for Story 3.4; `CleaningAction`/`CleaningResult` provenance for Story 3.3. 67 new tests; 268 passed / 0 regressions; security review clean. Not wired to orchestrator (deferred to 3.4). Status → review.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,0 +1,13 @@
+# Deferred Work
+
+Items surfaced during code review that are real but not currently reachable — not actionable now, tracked here so they aren't lost if the assumption that makes them unreachable ever changes.
+
+## Deferred from: code review of 3-2-cleaning-engine-core (2026-07-21)
+
+- **`CleaningEngine._normalize_case` / `_coerce_types` only consult `defect.affected_columns[0]`.** If Story 3.1's classifier (or a future detector) ever emits a `case_inconsistency`/`mixed_types` finding spanning more than one column, only the first would be remediated and the rest would go silently unfixed with no corresponding action. Currently unreachable: `backend/pipeline/data_quality.py` always constructs these defects with a single-element `affected_columns` list. If a future detector changes this, `cleaning_engine.py`'s per-column dispatch needs to iterate `affected_columns` instead of indexing `[0]`.
+
+- **`CleaningEngine` dispatches `duplicate_rows` (deduplication) per-finding like a column-scoped op, even though it's a whole-table operation.** If the classifier ever emitted more than one `duplicate_rows` finding in a single report, every call after the first would find zero further exact duplicates and log a confusing "Removed 0 exact duplicate row(s)" action. Currently unreachable: `backend/pipeline/data_quality.py`'s `_check_uniqueness` emits at most one `duplicate_rows` defect per assessment. If that ever changes, dedup should be batch-dispatched like `HEADER_NORMALIZATION` already is.
+
+- **`cleaning_primitives.normalize_column_names`'s `value_mapping` can silently drop an entry, and the per-column primitives (`normalize_case`, `coerce_column_type`) can misbehave, when the input frame has duplicate column labels** (pandas permits this; `working[column]` for a duplicate-labeled column returns a `DataFrame` slice, not a `Series`). Currently unreachable via this pipeline: the only ingestion path is `pd.read_csv` (`backend/pipeline/orchestrator.py`), which disambiguates duplicate headers on read. Would need a guard if a non-CSV ingestion path is ever added.
+
+- **`working = df.copy(deep=True)` does not recursively deep-copy nested mutable Python objects living in `object`-dtype cells** (e.g. a cell holding a `list`/`dict`). No current primitive mutates cell contents in place, so this is inert today, but the engine's module docstring makes an unconditional "never mutated on any path" claim that is broader than what `deep=True` technically guarantees. Worth revisiting if a future primitive ever does in-place cell mutation, or if the pipeline ever ingests a format that can produce non-scalar cell values.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -37,7 +37,7 @@
 #     (applies to all stories from 1.4 onward)
 
 generated: 2026-04-14
-last_updated: 2026-07-20  # Epic 3 merges landed in order: #40 (CI) → #39 (3.1 impl, 3-1→review) → #41 (3.2 spec, 3-2→ready-for-dev). Story 3.2 implementation begins next.
+last_updated: 2026-07-20  # Story 3.2 (Cleaning Engine core) implemented → review. 268 passed/0 regressions; security-reviewed; not wired to orchestrator (deferred to 3.4).
 project: SAINT
 project_key: NOKEY
 tracking_system: file-system
@@ -86,7 +86,7 @@ development_status:
   # =========================================================================
   epic-3: in-progress
   3-1-classification-layer:                    { status: review, loop_eligible: false }  # M/Opus — remediation_class taxonomy; architecture-defining; story-filed 2026-07-12; implemented 2026-07-20 (232 passed/0 regressions, security-reviewed) — merged via PR #39
-  3-2-cleaning-engine-core:                    { status: ready-for-dev, loop_eligible: false }  # L/Opus — deterministic only; story-filed 2026-07-20 (PR #41); dev begins now (PR #39 merged, RemediationClass on main)
+  3-2-cleaning-engine-core:                    { status: review, loop_eligible: false }  # L/Opus — deterministic only; implemented 2026-07-20 (268 passed/0 regressions, security-reviewed) — awaiting review/merge
   3-3-healing-manifest:                        { status: backlog, loop_eligible: false }  # M/Opus — provenance-critical
   3-4-opt-in-gate-config:                      { status: backlog, loop_eligible: false }  # M/Opus — Tier 2 policy boundary; default OFF
   3-5-judgment-required-findings-handling:     { status: backlog, loop_eligible: false }  # M/Opus — Tier 3 boundary; LOAD-BEARING

--- a/backend/cleaner.py
+++ b/backend/cleaner.py
@@ -1,3 +1,10 @@
+# STATUS: LEGACY — do not import from new code. Delegates to the unfactored
+# `advanced_pipeline.DataCleaner` (on the project-context legacy list) and has no
+# tests. It is NOT the deterministic Cleaning Engine. The Tier-based cleaning
+# introduced in Epic 3 lives in `backend/pipeline/cleaning_engine.py` +
+# `cleaning_primitives.py` (Story 3.2); this file is left untouched and unwired,
+# pending the factory refactor noted in project-context.md. New cleaning work
+# must target the pipeline modules, never this one.
 import pandas as pd
 from advanced_pipeline import DataCleaner
 

--- a/backend/errors/exceptions.py
+++ b/backend/errors/exceptions.py
@@ -29,7 +29,8 @@ Hierarchy
     ├── PipelineStageError             (any stage failed internally)
     │   ├── LLMProviderError           (Claude/OpenAI/Gemini call failed)
     │   ├── ReportRenderError          (DOCX/PDF render failed)
-    │   └── DriftComputationError      (baseline vs current stats failed)
+    │   ├── DriftComputationError      (baseline vs current stats failed)
+    │   └── CleaningEngineError        (cleaning contract violated / primitive failed)
     └── ConfigurationError             (bad env / YAML / missing key)
 
 ``ConfigurationError`` is intentionally a *sibling* of
@@ -94,6 +95,24 @@ class DriftComputationError(PipelineStageError):
 
     Typical causes: baseline file corrupt, insufficient rows for the
     chosen statistical test, scipy raised on degenerate input.
+    """
+
+
+class CleaningEngineError(PipelineStageError):
+    """The deterministic Cleaning Engine hit a contract violation (Story 3.2).
+
+    This is NOT raised for bad data — cleaning bad data is the engine's job.
+    It is raised when the engine is asked to do something the cleaning
+    invariants forbid, the load-bearing case being **a non-``agent_autonomous``
+    finding reaching the private per-finding dispatch**. The public
+    :meth:`CleaningEngine.clean` path filters to autonomous findings before
+    dispatch; this exception is the independent second guard, so a Tier-2/Tier-3
+    (or unknown-class) finding that somehow reaches the dispatch fails loudly
+    rather than silently mutating data that must stay human-owned.
+
+    Also raised if the private dispatch is handed a ``defect_type`` with no
+    registered autonomous operation (fail-closed: the engine refuses rather
+    than guesses).
     """
 
 

--- a/backend/models/cleaning_result.py
+++ b/backend/models/cleaning_result.py
@@ -1,0 +1,120 @@
+"""Cleaning-engine Pydantic models (Story 3.2).
+
+Defines the structured record the deterministic Cleaning Engine emits: one
+:class:`CleaningAction` per remediation applied (or skipped/failed), aggregated
+into a :class:`CleaningResult`.
+
+**This is the single source of provenance for Story 3.3's Healing Manifest.**
+Every field a manifest needs to describe *what happened to the data* lives here,
+so 3.3 renders from this model and never re-inspects or reconstructs the
+mutation. Do not add a parallel manifest format — extend this instead.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+from backend.models.quality_report import RemediationClass
+
+
+class CleaningOperation(str, Enum):
+    """The deterministic remediations the engine can apply.
+
+    The four autonomous operations map 1:1 from a Tier-1 ``defect_type`` (see
+    :mod:`backend.pipeline.cleaning_engine`). ``NULL_IMPUTATION`` is the
+    policy-less primitive Story 3.4 will drive through the Tier-2 policy layer;
+    it is **never** reached by the autonomous path.
+    """
+
+    DEDUPLICATION = "deduplication"
+    CASE_NORMALIZATION = "case_normalization"
+    TYPE_COERCION = "type_coercion"
+    HEADER_NORMALIZATION = "header_normalization"
+    NULL_IMPUTATION = "null_imputation"
+    # Sentinel for a recorded action where no remediation ran (a SKIPPED
+    # autonomous finding the engine has no operation for). Never an applied fix.
+    NO_OP = "no_op"
+
+
+class CleaningScope(str, Enum):
+    """What granularity an action touched — helps the manifest phrase itself."""
+
+    COLUMN = "column"  # one or more named columns
+    ROW = "row"  # whole rows (deduplication)
+    TABLE = "table"  # table-level structure (header normalization)
+
+
+class CleaningStatus(str, Enum):
+    """Outcome of a single action."""
+
+    APPLIED = "applied"  # remediation ran and changed the working copy
+    SKIPPED = "skipped"  # deliberately not applied (fail-closed); no change
+    FAILED = "failed"  # a primitive raised; working copy left at last-good state
+
+
+class CleaningAction(BaseModel):
+    """A single remediation the engine attempted, with full provenance.
+
+    Carries everything Story 3.3 needs to render one manifest line without
+    touching the data again: which finding drove it, which operation ran, the
+    before/after state, how much changed, the deterministic rule used, and —
+    on the non-applied paths — a safe reason or error string.
+    """
+
+    operation: CleaningOperation
+    defect_type: str
+    remediation_class: RemediationClass
+    status: CleaningStatus
+    scope: CleaningScope
+    # Columns the action targeted. For ROW scope (dedup) this is the full column
+    # list the duplicate spanned; for TABLE scope (header) the columns renamed.
+    target_columns: list[str] = Field(default_factory=list)
+    # Row-level effect (rows removed by dedup). Cell-level effect (values
+    # rewritten by case/coercion). Both default 0 so a manifest can sum them.
+    rows_affected: int = 0
+    values_changed: int = 0
+    # Compact, human/machine-readable snapshots of state either side of the
+    # change (e.g. "50 rows" -> "48 rows"; "{North, north, NORTH}" -> "north").
+    before_state: str = ""
+    after_state: str = ""
+    # Structured old->new mapping for the operations whose provenance IS a
+    # mapping: case variant->canonical, and header old->new. Empty otherwise.
+    value_mapping: dict[str, str] = Field(default_factory=dict)
+    # Deterministic parameters that fully determine the result given the input
+    # (e.g. dominant_type, uncoerced count, tie_break rule). All stringified so
+    # the record stays JSON-safe and manifest-renderable.
+    parameters: dict[str, str] = Field(default_factory=dict)
+    # The deterministic rule applied, stated so the manifest can cite it.
+    rule: str = ""
+    # Human-readable one-liner.
+    detail: str = ""
+    # Safe error information on the FAILED path — exception type + message only,
+    # never raw row data or PII. ``None`` on applied/skipped.
+    error: str | None = None
+
+
+class CleaningResult(BaseModel):
+    """Aggregate record of one cleaning pass — the manifest's root object.
+
+    Returned alongside the cleaned DataFrame from
+    :meth:`backend.pipeline.cleaning_engine.CleaningEngine.clean`. The frame and
+    this record travel separately (a DataFrame is not a Pydantic-serializable
+    stage boundary type); this object is the durable, serializable half.
+    """
+
+    pipeline_run_id: str
+    # Findings the engine saw vs. the autonomous subset it was allowed to act on.
+    total_findings: int
+    autonomous_findings: int
+    actions: list[CleaningAction] = Field(default_factory=list)
+    # Frame shape either side of the pass — lets the manifest state net effect
+    # without recomputing from the data.
+    rows_before: int
+    rows_after: int
+    columns_before: int
+    columns_after: int
+    # Envelope timestamp (ISO 8601 UTC). The ONLY non-deterministic value in the
+    # result; data values never depend on it.
+    cleaned_at: str

--- a/backend/pipeline/cleaning_engine.py
+++ b/backend/pipeline/cleaning_engine.py
@@ -73,6 +73,16 @@ class CleaningEngine:
         CleaningOperation.HEADER_NORMALIZATION,
     )
 
+    # Scope each operation would use in a FAILED provenance record, so a
+    # failure is never mis-recorded under the wrong CleaningScope (e.g. a
+    # failed dedup must read ROW, not COLUMN).
+    _SCOPE_BY_OPERATION: dict[CleaningOperation, CleaningScope] = {
+        CleaningOperation.DEDUPLICATION: CleaningScope.ROW,
+        CleaningOperation.CASE_NORMALIZATION: CleaningScope.COLUMN,
+        CleaningOperation.TYPE_COERCION: CleaningScope.COLUMN,
+        CleaningOperation.HEADER_NORMALIZATION: CleaningScope.TABLE,
+    }
+
     def clean(
         self,
         df: pd.DataFrame,
@@ -120,7 +130,23 @@ class CleaningEngine:
             if operation == CleaningOperation.HEADER_NORMALIZATION:
                 # Frame-level op: one action for all flagged columns at once so
                 # collision suffixing is consistent across the whole header row.
-                working, action = self._normalize_headers(bucket, working, log)
+                # Wrapped identically to the per-finding loop below so a failure
+                # here degrades to a FAILED action instead of aborting clean().
+                try:
+                    working, action = self._normalize_headers(bucket, working, log)
+                except CleaningEngineError:
+                    raise
+                except Exception as exc:  # noqa: BLE001 - captured as safe provenance
+                    actions.append(
+                        self._failed_action(bucket[0], operation, exc)
+                    )
+                    log.warning(
+                        "cleaning_action_failed",
+                        operation=operation.value,
+                        defect_type="column_naming",
+                        error_type=type(exc).__name__,
+                    )
+                    continue
                 actions.append(action)
                 continue
 
@@ -358,7 +384,12 @@ class CleaningEngine:
         working: pd.DataFrame,
         log: structlog.stdlib.BoundLogger,
     ) -> tuple[pd.DataFrame, CleaningAction]:
-        """Normalize ALL flagged headers in one pass (collision-safe across frame)."""
+        """Normalize ONLY the flagged headers in one pass, collision-safe across the
+        whole frame. Columns with no ``column_naming`` finding — including any
+        that happen to already be well-formed — are left byte-identical; they
+        still participate in collision detection so a rename can never clash
+        with an untouched name.
+        """
         # Independent guard applies here too — every finding in the batch must be
         # autonomous (clean() only ever passes autonomous ones, but assert it).
         for defect in defects:
@@ -369,7 +400,10 @@ class CleaningEngine:
                     f"remediation_class={defect.remediation_class.value!r}"
                 )
 
-        new_columns, mapping = prim.normalize_column_names(list(working.columns))
+        targets = {d.affected_columns[0] for d in defects if d.affected_columns}
+        new_columns, mapping = prim.normalize_column_names(
+            list(working.columns), targets=targets
+        )
         updated = working.copy()
         updated.columns = new_columns
         log.info(
@@ -419,15 +453,19 @@ class CleaningEngine:
         operation: CleaningOperation,
         exc: Exception,
     ) -> CleaningAction:
-        """Build a FAILED action with safe error info (type + message only)."""
+        """Build a FAILED action with safe error info (type + truncated message)."""
+        # Cap the message: pandas coercion/parse exceptions can embed the
+        # offending cell's repr, and this record is the Healing Manifest's
+        # source of truth — it must not become a backdoor for raw data.
+        safe_message = str(exc)[:200]
         return CleaningAction(
             operation=operation,
             defect_type=defect.defect_type,
             remediation_class=defect.remediation_class,
             status=CleaningStatus.FAILED,
-            scope=CleaningScope.COLUMN,
+            scope=self._SCOPE_BY_OPERATION.get(operation, CleaningScope.COLUMN),
             target_columns=list(defect.affected_columns),
             rule="operation raised; working copy left at last-good state",
             detail=f"Cleaning action for '{defect.defect_type}' did not complete.",
-            error=f"{type(exc).__name__}: {exc}",
+            error=f"{type(exc).__name__}: {safe_message}",
         )

--- a/backend/pipeline/cleaning_engine.py
+++ b/backend/pipeline/cleaning_engine.py
@@ -1,0 +1,433 @@
+"""Deterministic Cleaning Engine — core (Story 3.2).
+
+The first code path in SAINT that MODIFIES data. It applies the four Tier-1
+rules-based remediations to a **working copy** of the input, acting autonomously
+ONLY on findings the classifier stamped ``agent_autonomous``, and returns the
+cleaned copy plus a :class:`~backend.models.cleaning_result.CleaningResult`
+recording every action (the single source Story 3.3 renders the healing manifest
+from).
+
+Safety invariants (Epic 3, load-bearing — a bug here silently mutates a client's
+data, a failure a passing report would not reveal):
+
+* **Working-copy only.** A deep copy is taken at entry; the caller's frame is
+  never mutated, on any path including errors.
+* **Tier-1-only, fail-closed twice.** The public path filters to
+  ``agent_autonomous`` findings; the private per-finding dispatch independently
+  re-checks and raises :class:`CleaningEngineError` on anything else. There is no
+  flag that widens this.
+* **Not wired to the orchestrator.** Cleaning is opt-in / default-off; the gate
+  that makes wiring safe is Story 3.4. This module is callable but unwired.
+
+Architecture compliance (architecture.md §482-506, §745): ``backend/pipeline/``;
+imports only ``models``/``errors``/siblings; never ``api``/``agents``/legacy
+(notably NOT legacy ``backend/cleaner.py``); no import-time side effects;
+structlog events carry ``pipeline_run_id`` and never log raw row data or PII.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pandas as pd
+import structlog
+
+from backend.errors.exceptions import CleaningEngineError
+from backend.models.cleaning_result import (
+    CleaningAction,
+    CleaningOperation,
+    CleaningResult,
+    CleaningScope,
+    CleaningStatus,
+)
+from backend.models.quality_report import (
+    DataQualityDefect,
+    DataQualityReport,
+    RemediationClass,
+)
+from backend.pipeline import cleaning_primitives as prim
+
+
+class CleaningEngine:
+    """Applies Tier-1 deterministic remediations to a working copy of a frame."""
+
+    # Authoritative defect_type -> operation registry. Keyed on ``defect_type``
+    # (never ``category``), mirroring the classifier: a future Tier-3 variant
+    # sharing a category cannot inherit an autonomous operation, and any
+    # defect_type absent here has no autonomous path at all.
+    _OPERATION_BY_DEFECT_TYPE: dict[str, CleaningOperation] = {
+        "mixed_types": CleaningOperation.TYPE_COERCION,
+        "case_inconsistency": CleaningOperation.CASE_NORMALIZATION,
+        "duplicate_rows": CleaningOperation.DEDUPLICATION,
+        "column_naming": CleaningOperation.HEADER_NORMALIZATION,
+    }
+
+    # Deterministic processing order. Column-name-keyed ops (coercion, case) run
+    # before header normalization so they resolve against the ORIGINAL names;
+    # deduplication runs on the transformed frame (normalization can expose new
+    # exact duplicates); header renaming is last.
+    _PROCESSING_ORDER: tuple[CleaningOperation, ...] = (
+        CleaningOperation.TYPE_COERCION,
+        CleaningOperation.CASE_NORMALIZATION,
+        CleaningOperation.DEDUPLICATION,
+        CleaningOperation.HEADER_NORMALIZATION,
+    )
+
+    def clean(
+        self,
+        df: pd.DataFrame,
+        quality_report: DataQualityReport,
+        pipeline_run_id: str,
+    ) -> tuple[pd.DataFrame, CleaningResult]:
+        """Clean a working copy of ``df`` per the autonomous findings in the report.
+
+        Returns ``(cleaned_df, result)``. ``df`` itself is never modified. Only
+        ``agent_autonomous`` findings are acted on; everything else is left
+        exactly as-is. An empty or all-non-autonomous report yields the frame
+        deep-copied and a result with no actions.
+        """
+        log = structlog.get_logger().bind(pipeline_run_id=pipeline_run_id)
+
+        # --- Working-copy invariant: deep copy at the boundary. ---
+        working = df.copy(deep=True)
+        rows_before, columns_before = working.shape
+
+        defects = quality_report.defects
+        autonomous = [
+            d
+            for d in defects
+            if d.remediation_class == RemediationClass.AGENT_AUTONOMOUS
+        ]
+        log.info(
+            "cleaning_started",
+            total_findings=len(defects),
+            autonomous_findings=len(autonomous),
+            rows=rows_before,
+            columns=columns_before,
+        )
+
+        actions: list[CleaningAction] = []
+
+        for operation in self._PROCESSING_ORDER:
+            bucket = [
+                d
+                for d in autonomous
+                if self._OPERATION_BY_DEFECT_TYPE.get(d.defect_type) == operation
+            ]
+            if not bucket:
+                continue
+
+            if operation == CleaningOperation.HEADER_NORMALIZATION:
+                # Frame-level op: one action for all flagged columns at once so
+                # collision suffixing is consistent across the whole header row.
+                working, action = self._normalize_headers(bucket, working, log)
+                actions.append(action)
+                continue
+
+            # Per-column / per-finding ops, sorted for deterministic order.
+            for defect in sorted(
+                bucket,
+                key=lambda d: (d.affected_columns[0] if d.affected_columns else ""),
+            ):
+                try:
+                    working, action = self._apply_operation(
+                        defect, operation, working, log
+                    )
+                except CleaningEngineError:
+                    # Contract violation — must surface, not be swallowed. The
+                    # working copy for THIS op was not assigned, so the frame is
+                    # at its last-good state and the original is untouched.
+                    raise
+                except Exception as exc:  # noqa: BLE001 - captured as safe provenance
+                    actions.append(
+                        self._failed_action(defect, operation, exc)
+                    )
+                    log.warning(
+                        "cleaning_action_failed",
+                        operation=operation.value,
+                        defect_type=defect.defect_type,
+                        error_type=type(exc).__name__,
+                    )
+                    continue
+                actions.append(action)
+
+        # Fail-closed provenance: any autonomous finding whose defect_type has no
+        # registered operation is recorded as SKIPPED (zero data change) rather
+        # than silently ignored. With the current classifier this cannot happen
+        # (only the four registered types are autonomous); a SKIPPED entry here
+        # is a visible signal of classifier/engine drift.
+        for defect in sorted(
+            (
+                d
+                for d in autonomous
+                if self._OPERATION_BY_DEFECT_TYPE.get(d.defect_type) is None
+            ),
+            key=lambda d: (d.defect_type, d.affected_columns[0] if d.affected_columns else ""),
+        ):
+            actions.append(self._skipped_action(defect))
+            log.warning(
+                "cleaning_action_skipped",
+                defect_type=defect.defect_type,
+                reason="no_registered_autonomous_operation",
+            )
+
+        rows_after, columns_after = working.shape
+        log.info(
+            "cleaning_completed",
+            actions=len(actions),
+            rows_before=rows_before,
+            rows_after=rows_after,
+            columns_before=columns_before,
+            columns_after=columns_after,
+        )
+
+        result = CleaningResult(
+            pipeline_run_id=pipeline_run_id,
+            total_findings=len(defects),
+            autonomous_findings=len(autonomous),
+            actions=actions,
+            rows_before=rows_before,
+            rows_after=rows_after,
+            columns_before=columns_before,
+            columns_after=columns_after,
+            cleaned_at=datetime.now(timezone.utc).isoformat(),
+        )
+        return working, result
+
+    # ------------------------------------------------------------------
+    # Private per-finding dispatch — the independent second guard (AC 2).
+    # ------------------------------------------------------------------
+
+    def _apply_operation(
+        self,
+        defect: DataQualityDefect,
+        operation: CleaningOperation,
+        working: pd.DataFrame,
+        log: structlog.stdlib.BoundLogger,
+    ) -> tuple[pd.DataFrame, CleaningAction]:
+        """Apply one column/row operation; refuse anything non-autonomous.
+
+        Independently re-checks the finding's class (defense in depth: even if a
+        caller bypasses :meth:`clean`'s filter, a non-``agent_autonomous`` finding
+        raises here rather than mutating data). Also refuses a ``defect_type``
+        with no registered autonomous operation.
+        """
+        if defect.remediation_class != RemediationClass.AGENT_AUTONOMOUS:
+            raise CleaningEngineError(
+                "refusing to clean a non-autonomous finding: "
+                f"defect_type={defect.defect_type!r}, "
+                f"remediation_class={defect.remediation_class.value!r}"
+            )
+        if self._OPERATION_BY_DEFECT_TYPE.get(defect.defect_type) is None:
+            raise CleaningEngineError(
+                "no autonomous operation registered for "
+                f"defect_type={defect.defect_type!r}"
+            )
+
+        if operation == CleaningOperation.DEDUPLICATION:
+            return self._deduplicate(defect, working, log)
+        if operation == CleaningOperation.CASE_NORMALIZATION:
+            return self._normalize_case(defect, working, log)
+        if operation == CleaningOperation.TYPE_COERCION:
+            return self._coerce_types(defect, working, log)
+        # HEADER_NORMALIZATION is handled at the batch level in clean();
+        # reaching here means a single-finding dispatch was requested for it.
+        raise CleaningEngineError(
+            f"operation {operation.value!r} is not dispatched per-finding"
+        )
+
+    def _deduplicate(
+        self,
+        defect: DataQualityDefect,
+        working: pd.DataFrame,
+        log: structlog.stdlib.BoundLogger,
+    ) -> tuple[pd.DataFrame, CleaningAction]:
+        deduped, removed = prim.drop_exact_duplicates(working)
+        log.info(
+            "cleaning_action_applied",
+            operation=CleaningOperation.DEDUPLICATION.value,
+            rows_removed=removed,
+        )
+        action = CleaningAction(
+            operation=CleaningOperation.DEDUPLICATION,
+            defect_type=defect.defect_type,
+            remediation_class=defect.remediation_class,
+            status=CleaningStatus.APPLIED,
+            scope=CleaningScope.ROW,
+            target_columns=[str(c) for c in working.columns],
+            rows_affected=removed,
+            before_state=f"{len(working)} rows",
+            after_state=f"{len(deduped)} rows",
+            rule="drop exact duplicate rows, keep first occurrence, preserve order",
+            detail=f"Removed {removed} exact duplicate row(s).",
+        )
+        return deduped, action
+
+    def _normalize_case(
+        self,
+        defect: DataQualityDefect,
+        working: pd.DataFrame,
+        log: structlog.stdlib.BoundLogger,
+    ) -> tuple[pd.DataFrame, CleaningAction]:
+        column = defect.affected_columns[0]
+        new_series, meta = prim.normalize_case(working[column])
+        updated = working.copy()
+        updated[column] = new_series
+        mapping: dict[str, str] = meta["mapping"]
+        log.info(
+            "cleaning_action_applied",
+            operation=CleaningOperation.CASE_NORMALIZATION.value,
+            column=column,
+            values_changed=meta["values_changed"],
+            variants_collapsed=len(mapping),
+        )
+        action = CleaningAction(
+            operation=CleaningOperation.CASE_NORMALIZATION,
+            defect_type=defect.defect_type,
+            remediation_class=defect.remediation_class,
+            status=CleaningStatus.APPLIED,
+            scope=CleaningScope.COLUMN,
+            target_columns=[column],
+            values_changed=meta["values_changed"],
+            value_mapping=mapping,
+            before_state=f"{len(mapping)} non-canonical case variant(s)",
+            after_state="canonical case per value group",
+            rule=(
+                "collapse case variants to the most frequent original variant; "
+                "ties break to the lexicographically smallest variant"
+            ),
+            detail=(
+                f"Normalized casing in '{column}': "
+                f"{meta['values_changed']} value(s) rewritten across "
+                f"{len(mapping)} variant(s)."
+            ),
+        )
+        return updated, action
+
+    def _coerce_types(
+        self,
+        defect: DataQualityDefect,
+        working: pd.DataFrame,
+        log: structlog.stdlib.BoundLogger,
+    ) -> tuple[pd.DataFrame, CleaningAction]:
+        column = defect.affected_columns[0]
+        before_dtype = str(working[column].dtype)
+        new_series, meta = prim.coerce_column_type(working[column])
+        updated = working.copy()
+        updated[column] = new_series
+        after_dtype = str(updated[column].dtype)
+        log.info(
+            "cleaning_action_applied",
+            operation=CleaningOperation.TYPE_COERCION.value,
+            column=column,
+            kind=meta["kind"],
+            values_changed=meta["values_changed"],
+            uncoerced=meta["uncoerced"],
+        )
+        action = CleaningAction(
+            operation=CleaningOperation.TYPE_COERCION,
+            defect_type=defect.defect_type,
+            remediation_class=defect.remediation_class,
+            status=CleaningStatus.APPLIED,
+            scope=CleaningScope.COLUMN,
+            target_columns=[column],
+            values_changed=meta["values_changed"],
+            before_state=f"dtype={before_dtype}",
+            after_state=f"dtype={after_dtype}",
+            parameters={
+                "kind": str(meta["kind"]),
+                "dominant_type": str(meta["dominant_type"]),
+                "uncoerced": str(meta["uncoerced"]),
+            },
+            rule=(
+                "strip whitespace, then coerce minority values toward the "
+                "dominant type; values that fail to coerce keep their original "
+                "(never nulled)"
+            ),
+            detail=(
+                f"Coerced '{column}' toward {meta['dominant_type']} "
+                f"({meta['kind']}): {meta['values_changed']} value(s) rewritten, "
+                f"{meta['uncoerced']} left unchanged (uncoercible)."
+            ),
+        )
+        return updated, action
+
+    def _normalize_headers(
+        self,
+        defects: list[DataQualityDefect],
+        working: pd.DataFrame,
+        log: structlog.stdlib.BoundLogger,
+    ) -> tuple[pd.DataFrame, CleaningAction]:
+        """Normalize ALL flagged headers in one pass (collision-safe across frame)."""
+        # Independent guard applies here too — every finding in the batch must be
+        # autonomous (clean() only ever passes autonomous ones, but assert it).
+        for defect in defects:
+            if defect.remediation_class != RemediationClass.AGENT_AUTONOMOUS:
+                raise CleaningEngineError(
+                    "refusing to normalize a header for a non-autonomous finding: "
+                    f"defect_type={defect.defect_type!r}, "
+                    f"remediation_class={defect.remediation_class.value!r}"
+                )
+
+        new_columns, mapping = prim.normalize_column_names(list(working.columns))
+        updated = working.copy()
+        updated.columns = new_columns
+        log.info(
+            "cleaning_action_applied",
+            operation=CleaningOperation.HEADER_NORMALIZATION.value,
+            columns_renamed=len(mapping),
+        )
+        action = CleaningAction(
+            operation=CleaningOperation.HEADER_NORMALIZATION,
+            defect_type="column_naming",
+            remediation_class=RemediationClass.AGENT_AUTONOMOUS,
+            status=CleaningStatus.APPLIED,
+            scope=CleaningScope.TABLE,
+            target_columns=list(mapping.keys()),
+            rows_affected=0,
+            values_changed=len(mapping),
+            value_mapping=mapping,
+            before_state=f"{len(mapping)} non-conforming header(s)",
+            after_state="normalized snake_case headers",
+            rule=(
+                "strip, collapse non-[A-Za-z0-9_] runs to '_', lowercase; "
+                "empty/numeric -> column_{position}; collisions suffixed _2, _3, …"
+            ),
+            detail=f"Renamed {len(mapping)} column header(s).",
+        )
+        return updated, action
+
+    def _skipped_action(self, defect: DataQualityDefect) -> CleaningAction:
+        """Build a SKIPPED action for an autonomous finding with no registered op."""
+        return CleaningAction(
+            operation=CleaningOperation.NO_OP,  # nothing ran
+            defect_type=defect.defect_type,
+            remediation_class=defect.remediation_class,
+            status=CleaningStatus.SKIPPED,
+            scope=CleaningScope.COLUMN,
+            target_columns=list(defect.affected_columns),
+            rule="no registered autonomous operation for this defect_type — failing closed",
+            detail=(
+                f"Finding '{defect.defect_type}' was classified autonomous but the "
+                "engine has no operation for it; skipped without modifying data."
+            ),
+        )
+
+    def _failed_action(
+        self,
+        defect: DataQualityDefect,
+        operation: CleaningOperation,
+        exc: Exception,
+    ) -> CleaningAction:
+        """Build a FAILED action with safe error info (type + message only)."""
+        return CleaningAction(
+            operation=operation,
+            defect_type=defect.defect_type,
+            remediation_class=defect.remediation_class,
+            status=CleaningStatus.FAILED,
+            scope=CleaningScope.COLUMN,
+            target_columns=list(defect.affected_columns),
+            rule="operation raised; working copy left at last-good state",
+            detail=f"Cleaning action for '{defect.defect_type}' did not complete.",
+            error=f"{type(exc).__name__}: {exc}",
+        )

--- a/backend/pipeline/cleaning_primitives.py
+++ b/backend/pipeline/cleaning_primitives.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import datetime as _dt
 import re
 from collections import Counter
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pandas as pd
@@ -63,15 +63,22 @@ def strip_whitespace(series: pd.Series) -> tuple[pd.Series, int]:
 def dominant_python_type(series: pd.Series) -> type | None:
     """Return the most common Python ``type`` among non-null cells.
 
-    Mirrors the assessor's own derivation
-    (``non_null.apply(type).value_counts().index[0]``,
-    :mod:`backend.pipeline.data_quality`) so the engine coerces toward exactly
-    the type the assessor considered dominant. ``None`` if all cells are null.
+    Counts via a plain :class:`collections.Counter` rather than
+    ``Series.value_counts()`` and breaks ties on ``(module, qualname)`` —
+    deterministically, independent of hash-seed or iteration order. An exact
+    count tie between two types (e.g. equally many ints and numeric strings)
+    is a realistic input; ``value_counts()`` does not guarantee a stable
+    tie-break across process runs (dict/hashtable iteration order can vary
+    under hash randomization), which would violate this engine's "no
+    iteration-order dependence" invariant. ``None`` if all cells are null.
     """
     non_null = series.dropna()
     if non_null.empty:
         return None
-    return non_null.map(type).value_counts().index[0]
+    counts = Counter(type(v) for v in non_null)
+    max_count = max(counts.values())
+    candidates = [t for t, c in counts.items() if c == max_count]
+    return sorted(candidates, key=lambda t: (t.__module__, t.__qualname__))[0]
 
 
 def _is_numeric_type(t: type) -> bool:
@@ -210,22 +217,52 @@ def _slug(name: Any, position: int) -> str:
 
 def normalize_column_names(
     columns: list[Any],
+    targets: set[str] | None = None,
 ) -> tuple[list[str], dict[str, str]]:
-    """Normalize a list of column names deterministically, collision-safe.
+    """Normalize column names deterministically, collision-safe.
 
-    Each name: strip → collapse non-``[A-Za-z0-9_]`` runs to ``_`` → collapse
-    repeats → trim ``_`` → lowercase. Empty or purely-numeric results become
-    ``column_{position}`` (0-based). A normalized name colliding with one already
-    assigned (in column order) is suffixed ``_2``, ``_3``, ….
+    Each name in ``targets`` (matched by ``str(name)``) is renamed: strip →
+    collapse non-``[A-Za-z0-9_]`` runs to ``_`` → collapse repeats → trim ``_``
+    → lowercase; empty or purely-numeric results become ``column_{position}``
+    (0-based). Columns NOT in ``targets`` pass through with their original name
+    **unchanged** — but still occupy a slot in collision detection, so a
+    renamed column can never silently collide with an untouched one.
+
+    ``targets=None`` renames every column (the historical/full-frame
+    behavior). Passing an explicit set is how the Cleaning Engine scopes a
+    header-normalization action to only the columns a finding actually
+    flagged, leaving every other column — including ones with no finding at
+    all — byte-identical.
+
+    A normalized name colliding with one already assigned is suffixed ``_2``,
+    ``_3``, …. Untouched columns are reserved in a first pass — before any
+    renaming — so a rename always de-collides against the FULL untouched set,
+    not just the untouched names that happen to appear earlier in the frame.
+    Untouched columns are therefore guaranteed byte-identical and never
+    suffixed, regardless of column order.
 
     Returns the new column list and a mapping of old → new for names that
     actually changed.
     """
-    new_columns: list[str] = []
+    new_columns: list[str | None] = [None] * len(columns)
     assigned: set[str] = set()
-    mapping: dict[str, str] = {}
 
+    # Pass 1: reserve every untouched name so renames can never collide with
+    # one, independent of position.
     for position, name in enumerate(columns):
+        name_str = str(name)
+        if targets is not None and name_str not in targets:
+            new_columns[position] = name_str
+            assigned.add(name_str)
+
+    # Pass 2: slug + de-collide every targeted (or, with targets=None, every)
+    # column against the reserved set plus renames assigned so far.
+    mapping: dict[str, str] = {}
+    for position, name in enumerate(columns):
+        name_str = str(name)
+        if targets is not None and name_str not in targets:
+            continue
+
         base = _slug(name, position)
         candidate = base
         suffix = 2
@@ -233,11 +270,13 @@ def normalize_column_names(
             candidate = f"{base}_{suffix}"
             suffix += 1
         assigned.add(candidate)
-        new_columns.append(candidate)
-        if candidate != str(name):
-            mapping[str(name)] = candidate
+        new_columns[position] = candidate
+        if candidate != name_str:
+            mapping[name_str] = candidate
 
-    return new_columns, mapping
+    # Every position is filled by exactly one of the two passes above
+    # (untouched vs. targeted are mutually exclusive and exhaustive).
+    return cast("list[str]", new_columns), mapping
 
 
 def impute_nulls(df: pd.DataFrame, column: str, method: str) -> pd.DataFrame:
@@ -271,6 +310,13 @@ def impute_nulls(df: pd.DataFrame, column: str, method: str) -> pd.DataFrame:
         )
     if column not in df.columns:
         raise ValueError(f"column {column!r} not in frame")
+    if method in ("mean", "median") and not pd.api.types.is_numeric_dtype(
+        df[column]
+    ):
+        raise ValueError(
+            f"method {method!r} requires a numeric column; "
+            f"{column!r} has dtype {df[column].dtype}"
+        )
 
     out = df.copy()
     col = out[column]

--- a/backend/pipeline/cleaning_primitives.py
+++ b/backend/pipeline/cleaning_primitives.py
@@ -1,0 +1,290 @@
+"""Deterministic cleaning primitives (Story 3.2).
+
+Pure, side-effect-free functions implementing the five PRD Phase-9 remediations.
+Each returns a NEW object (never mutates its argument) plus the metadata the
+:class:`~backend.pipeline.cleaning_engine.CleaningEngine` needs to build a
+:class:`~backend.models.cleaning_result.CleaningAction`.
+
+These functions carry no knowledge of ``remediation_class`` or the DQA report —
+they are the mechanical *how*, deliberately separated from the engine's *whether*
+(which findings may be touched). That separation lets Story 3.4's Tier-2 policy
+layer call :func:`impute_nulls` directly without importing the autonomous engine.
+
+Architecture compliance (architecture.md §482-506, §745): lives in
+``backend/pipeline/``; imports only stdlib + pandas/numpy; no ``api``/``agents``
+/legacy imports; no import-time side effects; no logging self-config.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from collections import Counter
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+# Imputation methods the policy-less primitive accepts. Story 3.4 selects one
+# per column through the Tier-2 policy layer; there is deliberately no default.
+IMPUTATION_METHODS: frozenset[str] = frozenset(
+    {"mean", "median", "mode", "forward_fill"}
+)
+
+# Column-name normalization pattern: any run of characters that is not an ASCII
+# letter, digit, or underscore collapses to a single underscore.
+_NON_SLUG_CHARS = re.compile(r"[^a-zA-Z0-9_]+")
+_MULTI_UNDERSCORE = re.compile(r"_+")
+
+
+def _cell_changed(before: Any, after: Any) -> bool:
+    """True iff a cell's value materially changed (NaN-aware, no NaN!=NaN noise)."""
+    before_na = pd.isna(before)
+    after_na = pd.isna(after)
+    if before_na and after_na:
+        return False
+    if before_na != after_na:
+        return True
+    return bool(before != after)
+
+
+def strip_whitespace(series: pd.Series) -> tuple[pd.Series, int]:
+    """Strip leading/trailing whitespace from string cells only.
+
+    Non-string cells (numbers, NaN, datetimes) pass through untouched. Returns
+    the new series and the count of cells whose value changed.
+    """
+    stripped = series.map(lambda v: v.strip() if isinstance(v, str) else v)
+    is_str = series.map(lambda v: isinstance(v, str))
+    changed = int((is_str & (stripped != series)).sum())
+    return stripped, changed
+
+
+def dominant_python_type(series: pd.Series) -> type | None:
+    """Return the most common Python ``type`` among non-null cells.
+
+    Mirrors the assessor's own derivation
+    (``non_null.apply(type).value_counts().index[0]``,
+    :mod:`backend.pipeline.data_quality`) so the engine coerces toward exactly
+    the type the assessor considered dominant. ``None`` if all cells are null.
+    """
+    non_null = series.dropna()
+    if non_null.empty:
+        return None
+    return non_null.map(type).value_counts().index[0]
+
+
+def _is_numeric_type(t: type) -> bool:
+    # bool is a subclass of int — exclude it; coercing booleans is not our job.
+    if issubclass(t, bool):
+        return False
+    return issubclass(t, (int, float, np.integer, np.floating))
+
+
+def _is_datetime_type(t: type) -> bool:
+    # pd.Timestamp subclasses datetime.datetime, so this covers it too.
+    return issubclass(t, (_dt.datetime, _dt.date))
+
+
+def coerce_column_type(series: pd.Series) -> tuple[pd.Series, dict[str, Any]]:
+    """Coerce a mixed-type column toward its dominant type, non-destructively.
+
+    Steps, in order:
+
+    1. Strip whitespace from string cells.
+    2. Determine the dominant Python type among non-null cells.
+    3. Coerce minority values toward it:
+
+       * numeric dominant → :func:`pandas.to_numeric` with ``errors="coerce"``,
+         but **only adopt values that converted**; a value that fails to convert
+         keeps its original (never becomes null).
+       * datetime dominant → parse and standardize to ISO-8601 date strings
+         (``YYYY-MM-DD``); failures keep their original.
+       * otherwise (string/other dominant) → whitespace normalization only.
+
+    Never introduces a new null. Returns the new series and metadata:
+    ``kind`` (numeric|datetime|whitespace_only|empty), ``dominant_type``,
+    ``values_changed`` (cells rewritten, incl. whitespace), ``uncoerced``
+    (non-null cells that could not be coerced and were preserved).
+    """
+    original = series
+    stripped, _ = strip_whitespace(series)
+    dominant = dominant_python_type(stripped)
+
+    if dominant is None:
+        return stripped, {
+            "kind": "empty",
+            "dominant_type": "none",
+            "values_changed": 0,
+            "uncoerced": 0,
+        }
+
+    if _is_numeric_type(dominant):
+        coerced = pd.to_numeric(stripped, errors="coerce")
+        ok_mask = coerced.notna()
+        failed_mask = coerced.isna() & stripped.notna()
+        result = stripped.astype(object).copy()
+        result[ok_mask] = coerced[ok_mask]
+        kind = "numeric"
+    elif _is_datetime_type(dominant):
+        parsed = pd.to_datetime(stripped, errors="coerce")
+        ok_mask = parsed.notna()
+        failed_mask = parsed.isna() & stripped.notna()
+        iso = parsed.dt.strftime("%Y-%m-%d")
+        result = stripped.astype(object).copy()
+        result[ok_mask] = iso[ok_mask]
+        kind = "datetime"
+    else:
+        # String/other dominant: whitespace normalization is the only safe,
+        # deterministic remediation. No type change.
+        result = stripped
+        failed_mask = pd.Series(False, index=series.index)
+        kind = "whitespace_only"
+
+    values_changed = int(
+        sum(
+            _cell_changed(b, a)
+            for b, a in zip(original.tolist(), result.tolist())
+        )
+    )
+    return result, {
+        "kind": kind,
+        "dominant_type": getattr(dominant, "__name__", str(dominant)),
+        "values_changed": values_changed,
+        "uncoerced": int(failed_mask.sum()),
+    }
+
+
+def normalize_case(series: pd.Series) -> tuple[pd.Series, dict[str, Any]]:
+    """Collapse case variants of string values to a single canonical form.
+
+    Per group of values equal under ``str.lower()``, the canonical form is the
+    most frequent original variant; ties break to the lexicographically smallest
+    variant (fully deterministic). Non-string cells pass through untouched.
+
+    Returns the new series and metadata: ``mapping`` (variant → canonical, only
+    for variants that changed) and ``values_changed``.
+    """
+    groups: dict[str, Counter] = {}
+    for value in series.dropna():
+        if not isinstance(value, str):
+            continue
+        groups.setdefault(value.lower(), Counter())[value] += 1
+
+    mapping: dict[str, str] = {}
+    for counter in groups.values():
+        max_count = max(counter.values())
+        canonical = sorted(v for v, c in counter.items() if c == max_count)[0]
+        for variant in counter:
+            if variant != canonical:
+                mapping[variant] = canonical
+
+    result = series.map(
+        lambda v: mapping.get(v, v) if isinstance(v, str) else v
+    )
+    values_changed = int(
+        series.map(lambda v: isinstance(v, str) and v in mapping).sum()
+    )
+    return result, {"mapping": mapping, "values_changed": values_changed}
+
+
+def drop_exact_duplicates(df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    """Drop exact duplicate rows, keeping the first occurrence.
+
+    Original row order of the surviving rows is preserved; the index is reset.
+    Returns the new frame and the number of rows removed.
+    """
+    before = len(df)
+    deduped = df.drop_duplicates(keep="first").reset_index(drop=True)
+    return deduped, before - len(deduped)
+
+
+def _slug(name: Any, position: int) -> str:
+    """Deterministic single-name normalization (see :func:`normalize_column_names`)."""
+    text = _NON_SLUG_CHARS.sub("_", str(name).strip())
+    text = _MULTI_UNDERSCORE.sub("_", text).strip("_").lower()
+    if text == "" or text.isdigit():
+        return f"column_{position}"
+    return text
+
+
+def normalize_column_names(
+    columns: list[Any],
+) -> tuple[list[str], dict[str, str]]:
+    """Normalize a list of column names deterministically, collision-safe.
+
+    Each name: strip → collapse non-``[A-Za-z0-9_]`` runs to ``_`` → collapse
+    repeats → trim ``_`` → lowercase. Empty or purely-numeric results become
+    ``column_{position}`` (0-based). A normalized name colliding with one already
+    assigned (in column order) is suffixed ``_2``, ``_3``, ….
+
+    Returns the new column list and a mapping of old → new for names that
+    actually changed.
+    """
+    new_columns: list[str] = []
+    assigned: set[str] = set()
+    mapping: dict[str, str] = {}
+
+    for position, name in enumerate(columns):
+        base = _slug(name, position)
+        candidate = base
+        suffix = 2
+        while candidate in assigned:
+            candidate = f"{base}_{suffix}"
+            suffix += 1
+        assigned.add(candidate)
+        new_columns.append(candidate)
+        if candidate != str(name):
+            mapping[str(name)] = candidate
+
+    return new_columns, mapping
+
+
+def impute_nulls(df: pd.DataFrame, column: str, method: str) -> pd.DataFrame:
+    """Impute nulls in one column using an explicit method (policy-less primitive).
+
+    **Story 3.2 ships this WITHOUT autonomy and WITHOUT a default.** It is Tier-2
+    (``human_policy_agent_execution``): the *choice* of method is a human policy
+    decision Story 3.4 will supply. The autonomous cleaning path never calls this
+    — it is exposed here purely so 3.4's policy layer can execute a chosen method.
+
+    Parameters
+    ----------
+    df:
+        Source frame (never mutated — a copy is returned).
+    column:
+        Column to impute.
+    method:
+        One of :data:`IMPUTATION_METHODS`. **Required** — there is no default,
+        so a caller must make the policy choice explicit.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is not a recognized imputation method, or ``column`` is
+        absent. Fail loudly rather than guess a fill.
+    """
+    if method not in IMPUTATION_METHODS:
+        raise ValueError(
+            f"unknown imputation method {method!r}; "
+            f"expected one of {sorted(IMPUTATION_METHODS)}"
+        )
+    if column not in df.columns:
+        raise ValueError(f"column {column!r} not in frame")
+
+    out = df.copy()
+    col = out[column]
+
+    if method == "forward_fill":
+        out[column] = col.ffill()
+        return out
+    if method == "mean":
+        fill = col.mean()
+    elif method == "median":
+        fill = col.median()
+    else:  # mode
+        modes = col.mode(dropna=True)
+        fill = modes.iloc[0] if not modes.empty else None
+
+    out[column] = col.fillna(fill)
+    return out

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -150,3 +150,60 @@ def drifted_sales_df(clean_sales_df: pd.DataFrame) -> pd.DataFrame:
     drifted = clean_sales_df.copy()
     drifted["revenue"] = (drifted["revenue"] * 1.4).round(2)
     return drifted
+
+
+# --- Story 3.2 (Cleaning Engine) additive fixture -------------------------
+# Row layout (12 rows) — positions chosen so the ONE dedup-removed row does not
+# overlap the Tier-2/Tier-3 findings in `quantity`, letting tests assert those
+# human-owned findings survive cleaning unchanged.
+_CLEAN_DIRTY_NULL_QTY_IDX = (0, 1)  # Tier-2 null_values
+_CLEAN_DIRTY_NEG_QTY_IDX = 2  # Tier-3 negative_values (quantity implies >= 0)
+_CLEAN_DIRTY_DUP_SRC_IDX = 5  # Tier-1 duplicate_rows source
+_CLEAN_DIRTY_DUP_DST_IDX = 6  # exact duplicate of row 5
+
+
+@pytest.fixture
+def cleaning_dirty_df() -> pd.DataFrame:
+    """12-row frame seeded with a KNOWN mix of Tier-1/2/3 defects.
+
+    The assessor emits exactly these defect types against it:
+
+    * Tier 1 (``agent_autonomous`` — the engine SHOULD fix):
+      - ``case_inconsistency`` in ``region`` (north/North/NORTH collapse).
+      - ``mixed_types`` in ``code`` (ints + numeric-as-string — fully coercible,
+        so coercion resolves the column and the defect disappears on re-assess).
+      - ``duplicate_rows`` (row 6 is an exact duplicate of row 5).
+      - ``column_naming`` in the header ``"amount#"`` (special char).
+    * Tier 2 (``human_policy_agent_execution`` — the engine must NOT touch):
+      - ``null_values`` in ``quantity`` (rows 0, 1).
+    * Tier 3 (``human_only`` — the engine must NEVER touch):
+      - ``negative_values`` in ``quantity`` (row 2 is ``-5``; ``quantity``
+        implies non-negativity).
+
+    The duplicate row (5/6) carries a positive, non-null ``quantity``, so
+    removing it leaves the Tier-2/Tier-3 quantity findings intact.
+    """
+    regions = [
+        "north", "North", "NORTH", "south", "south",
+        "east", "east", "west", "north", "south",
+        "NORTH", "west",
+    ]
+    quantity: list[Any] = [float(v) for v in (10, 20, -5, 40, 50, 60, 70, 80, 90, 100, 110, 120)]
+    quantity[_CLEAN_DIRTY_NULL_QTY_IDX[0]] = None
+    quantity[_CLEAN_DIRTY_NULL_QTY_IDX[1]] = None
+    quantity[_CLEAN_DIRTY_NEG_QTY_IDX] = -5.0
+    # code: object column mixing int and numeric-as-string (all coercible).
+    code: list[Any] = [10, 20, "30", 40, "50", 60, 70, "80", 90, 100, "110", 120]
+    amount = [float(v) for v in range(100, 220, 10)]  # 12 clean positive floats
+
+    df = pd.DataFrame(
+        {
+            "region": regions,
+            "quantity": quantity,
+            "code": code,
+            "amount#": amount,  # special char in header -> column_naming
+        }
+    )
+    # Make row DST an exact duplicate of row SRC across every column.
+    df.iloc[_CLEAN_DIRTY_DUP_DST_IDX] = df.iloc[_CLEAN_DIRTY_DUP_SRC_IDX]
+    return df

--- a/backend/tests/test_cleaning_engine.py
+++ b/backend/tests/test_cleaning_engine.py
@@ -1,0 +1,421 @@
+"""Tests for the deterministic Cleaning Engine (Story 3.2).
+
+Covers the load-bearing safety invariants (working-copy only, Tier-1-only
+fail-closed dispatch, human-owned findings never touched), each Tier-1
+operation's deterministic rule, the policy-less imputation boundary, action-
+record provenance, determinism/idempotency, and an assess→clean→re-assess
+integration pass.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from backend.errors.exceptions import CleaningEngineError
+from backend.models.cleaning_result import (
+    CleaningOperation,
+    CleaningResult,
+    CleaningStatus,
+)
+from backend.models.quality_report import (
+    DataQualityDefect,
+    DataQualityReport,
+    DefectCategory,
+    RemediationClass,
+    Severity,
+)
+from backend.pipeline import cleaning_primitives as prim
+from backend.pipeline.cleaning_engine import CleaningEngine
+from backend.pipeline.data_quality import DataQualityAssessor
+
+RUN_ID = "test-run-3-2"
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+def _defect(
+    defect_type: str,
+    remediation_class: RemediationClass,
+    affected_columns: list[str],
+    *,
+    category: DefectCategory = DefectCategory.STRUCTURAL_INTEGRITY,
+    severity: Severity = Severity.MEDIUM,
+) -> DataQualityDefect:
+    return DataQualityDefect(
+        defect_type=defect_type,
+        category=category,
+        severity=severity,
+        affected_columns=affected_columns,
+        count=1,
+        percentage=1.0,
+        details="test defect",
+        recommended_action="test action",
+        remediation_class=remediation_class,
+    )
+
+
+def _report(df: pd.DataFrame, defects: list[DataQualityDefect]) -> DataQualityReport:
+    return DataQualityReport(
+        overall_severity=Severity.MEDIUM,
+        has_critical_issues=False,
+        defects=defects,
+        column_profiles={},
+        total_rows=len(df),
+        total_columns=len(df.columns),
+        overall_quality_score=0.5,
+        assessed_at="2026-07-20T00:00:00Z",
+    )
+
+
+def _autonomous(defect_type: str, cols: list[str]) -> DataQualityDefect:
+    return _defect(defect_type, RemediationClass.AGENT_AUTONOMOUS, cols)
+
+
+# --------------------------------------------------------------------------
+# AC 1 — working-copy invariant
+# --------------------------------------------------------------------------
+class TestWorkingCopyInvariant:
+    def test_original_frame_never_mutated(self, cleaning_dirty_df: pd.DataFrame) -> None:
+        pristine = cleaning_dirty_df.copy(deep=True)
+        report = DataQualityAssessor().assess_quality(cleaning_dirty_df, RUN_ID).quality_report
+
+        CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+
+        pd.testing.assert_frame_equal(cleaning_dirty_df, pristine)
+
+    def test_returns_a_distinct_object(self, cleaning_dirty_df: pd.DataFrame) -> None:
+        report = DataQualityAssessor().assess_quality(cleaning_dirty_df, RUN_ID).quality_report
+        cleaned, result = CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+        assert cleaned is not cleaning_dirty_df
+        assert isinstance(result, CleaningResult)
+
+    def test_no_op_report_returns_deep_copy(self, clean_sales_df: pd.DataFrame) -> None:
+        report = _report(clean_sales_df, [])
+        cleaned, result = CleaningEngine().clean(clean_sales_df, report, RUN_ID)
+        assert result.actions == []
+        assert cleaned is not clean_sales_df
+        pd.testing.assert_frame_equal(cleaned, clean_sales_df)
+
+
+# --------------------------------------------------------------------------
+# AC 2 — Tier-1-only, fail-closed dispatch
+# --------------------------------------------------------------------------
+class TestFailClosedDispatch:
+    def test_tier2_and_tier3_findings_produce_no_change(self) -> None:
+        df = pd.DataFrame({"quantity": [1.0, None, -5.0, 4.0]})
+        defects = [
+            _defect("null_values", RemediationClass.HUMAN_POLICY_AGENT_EXECUTION, ["quantity"]),
+            _defect("negative_values", RemediationClass.HUMAN_ONLY, ["quantity"]),
+        ]
+        cleaned, result = CleaningEngine().clean(df, _report(df, defects), RUN_ID)
+        assert result.actions == []
+        pd.testing.assert_frame_equal(cleaned, df)
+
+    def test_unknown_defect_type_defaults_human_only_and_is_ignored(self) -> None:
+        df = pd.DataFrame({"a": [1, 2, 2]})
+        # Default remediation_class is HUMAN_ONLY (fail-safe) — filtered out.
+        d = DataQualityDefect(
+            defect_type="some_future_defect",
+            category=DefectCategory.STRUCTURAL_INTEGRITY,
+            severity=Severity.LOW,
+            affected_columns=["a"],
+            count=1,
+            percentage=1.0,
+            details="x",
+            recommended_action="y",
+        )
+        assert d.remediation_class == RemediationClass.HUMAN_ONLY
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert result.actions == []
+        pd.testing.assert_frame_equal(cleaned, df)
+
+    def test_autonomous_but_unregistered_type_fails_closed_with_skip_record(self) -> None:
+        df = pd.DataFrame({"quantity": [1.0, None, None]})
+        # A mis-stamped finding: autonomous class on a type the engine can't handle.
+        d = _autonomous("null_values", ["quantity"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        # Fail-closed: data unchanged, and a visible SKIPPED / NO_OP record emitted.
+        pd.testing.assert_frame_equal(cleaned, df)
+        assert len(result.actions) == 1
+        assert result.actions[0].status == CleaningStatus.SKIPPED
+        assert result.actions[0].operation == CleaningOperation.NO_OP
+        assert not any(a.operation == CleaningOperation.NULL_IMPUTATION for a in result.actions)
+
+    def test_private_dispatch_rejects_non_autonomous_finding(self) -> None:
+        df = pd.DataFrame({"a": ["x", "y"]})
+        d = _defect("case_inconsistency", RemediationClass.HUMAN_ONLY, ["a"])
+        with pytest.raises(CleaningEngineError, match="non-autonomous"):
+            CleaningEngine()._apply_operation(
+                d, CleaningOperation.CASE_NORMALIZATION, df, _stub_log()
+            )
+
+    def test_private_header_dispatch_rejects_non_autonomous_finding(self) -> None:
+        df = pd.DataFrame({"bad$": [1, 2]})
+        d = _defect("column_naming", RemediationClass.HUMAN_POLICY_AGENT_EXECUTION, ["bad$"])
+        with pytest.raises(CleaningEngineError, match="non-autonomous"):
+            CleaningEngine()._normalize_headers([d], df, _stub_log())
+
+    def test_mixed_list_processes_only_autonomous_findings(self) -> None:
+        df = pd.DataFrame(
+            {"region": ["a", "A", "a"], "quantity": [1.0, None, -5.0]}
+        )
+        defects = [
+            _autonomous("case_inconsistency", ["region"]),  # Tier 1 -> act
+            _defect("null_values", RemediationClass.HUMAN_POLICY_AGENT_EXECUTION, ["quantity"]),
+            _defect("negative_values", RemediationClass.HUMAN_ONLY, ["quantity"]),
+        ]
+        cleaned, result = CleaningEngine().clean(df, _report(df, defects), RUN_ID)
+        applied = [a for a in result.actions if a.status == CleaningStatus.APPLIED]
+        assert len(applied) == 1
+        assert applied[0].operation == CleaningOperation.CASE_NORMALIZATION
+        # quantity (Tier-2/3) untouched: null still null, negative still negative.
+        assert cleaned["quantity"].isna().sum() == 1
+        assert (cleaned["quantity"] == -5.0).sum() == 1
+
+
+# --------------------------------------------------------------------------
+# AC 3 — Tier-1 operation specs
+# --------------------------------------------------------------------------
+class TestDeduplication:
+    def test_removes_exact_duplicates_keep_first_preserve_order(self) -> None:
+        df = pd.DataFrame({"a": [1, 2, 2, 3], "b": ["x", "y", "y", "z"]})
+        d = _autonomous("duplicate_rows", ["a", "b"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert list(cleaned["a"]) == [1, 2, 3]
+        action = result.actions[0]
+        assert action.operation == CleaningOperation.DEDUPLICATION
+        assert action.rows_affected == 1
+        assert action.before_state == "4 rows" and action.after_state == "3 rows"
+
+
+class TestCaseNormalization:
+    def test_collapses_to_most_frequent_variant(self) -> None:
+        # "north" appears 3x, "North" 1x -> canonical "north".
+        df = pd.DataFrame({"region": ["north", "North", "north", "north"]})
+        d = _autonomous("case_inconsistency", ["region"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert list(cleaned["region"]) == ["north", "north", "north", "north"]
+        assert result.actions[0].value_mapping == {"North": "north"}
+        assert result.actions[0].values_changed == 1
+
+    def test_tie_breaks_to_lexicographically_smallest(self) -> None:
+        # "North" 1x, "north" 1x -> tie -> lexicographically smallest "North".
+        df = pd.DataFrame({"region": ["North", "north"]})
+        d = _autonomous("case_inconsistency", ["region"])
+        cleaned, _ = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert list(cleaned["region"]) == ["North", "North"]
+
+    def test_non_string_cells_untouched(self) -> None:
+        series = pd.Series(["a", "A", 5, None], dtype=object)
+        out, meta = prim.normalize_case(series)
+        assert out.iloc[2] == 5
+        assert pd.isna(out.iloc[3])
+
+
+class TestTypeCoercion:
+    def test_coerces_numeric_strings_to_numbers(self) -> None:
+        df = pd.DataFrame({"code": [1, 2, "3", 4, "5"]})
+        d = _autonomous("mixed_types", ["code"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert list(pd.to_numeric(cleaned["code"])) == [1, 2, 3, 4, 5]
+        assert result.actions[0].parameters["uncoerced"] == "0"
+
+    def test_uncoercible_value_preserved_not_nulled(self) -> None:
+        df = pd.DataFrame({"code": [1, 2, "oops", 4, 5]})
+        d = _autonomous("mixed_types", ["code"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        # The uncoercible string is kept, NOT replaced with null.
+        assert "oops" in list(cleaned["code"])
+        assert cleaned["code"].isna().sum() == 0
+        assert result.actions[0].parameters["uncoerced"] == "1"
+
+    def test_whitespace_stripped_during_coercion(self) -> None:
+        out, meta = prim.coerce_column_type(pd.Series([" 1 ", "2", " 3"]))
+        assert list(pd.to_numeric(out)) == [1, 2, 3]
+
+    def test_datetime_standardized_to_iso(self) -> None:
+        # Dominant type datetime (2 timestamps) + 1 string -> ISO date strings.
+        series = pd.Series(
+            [pd.Timestamp("2026-01-05"), pd.Timestamp("2026-01-06"), "2026-01-07"],
+            dtype=object,
+        )
+        out, meta = prim.coerce_column_type(series)
+        assert meta["kind"] == "datetime"
+        assert list(out) == ["2026-01-05", "2026-01-06", "2026-01-07"]
+
+    def test_never_introduces_new_null(self) -> None:
+        df = pd.DataFrame({"code": [1, "x", 3, "y", 5]})
+        d = _autonomous("mixed_types", ["code"])
+        cleaned, _ = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert cleaned["code"].isna().sum() == 0
+
+
+class TestHeaderNormalization:
+    def test_normalizes_special_and_numeric_names(self) -> None:
+        cols, mapping = prim.normalize_column_names(["Unit Price ($)", "2024", "  ok_col  "])
+        assert cols == ["unit_price", "column_1", "ok_col"]
+        assert mapping["2024"] == "column_1"
+
+    def test_collision_suffixing_is_deterministic(self) -> None:
+        cols, _ = prim.normalize_column_names(["A", "a", "a!"])
+        assert cols == ["a", "a_2", "a_3"]
+
+    def test_engine_renames_flagged_headers_in_one_action(self) -> None:
+        df = pd.DataFrame({"amount#": [1.0, 2.0], "clean": [3, 4]})
+        d = _autonomous("column_naming", ["amount#"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert list(cleaned.columns) == ["amount", "clean"]
+        header_actions = [
+            a for a in result.actions
+            if a.operation == CleaningOperation.HEADER_NORMALIZATION
+        ]
+        assert len(header_actions) == 1
+        assert header_actions[0].value_mapping == {"amount#": "amount"}
+
+
+# --------------------------------------------------------------------------
+# AC 4 — imputation boundary (policy-less primitive)
+# --------------------------------------------------------------------------
+class TestImputationPrimitive:
+    def test_mean_median_mode_forward_fill(self) -> None:
+        df = pd.DataFrame({"x": [1.0, None, 3.0, None, 3.0]})
+        assert prim.impute_nulls(df, "x", "mean")["x"].isna().sum() == 0
+        assert prim.impute_nulls(df, "x", "median")["x"].tolist()[1] == pytest.approx(3.0)
+        assert prim.impute_nulls(df, "x", "mode")["x"].tolist()[1] == pytest.approx(3.0)
+        ff = prim.impute_nulls(df, "x", "forward_fill")["x"].tolist()
+        assert ff == [1.0, 1.0, 3.0, 3.0, 3.0]
+
+    def test_method_argument_is_mandatory(self) -> None:
+        df = pd.DataFrame({"x": [1.0, None]})
+        with pytest.raises(TypeError):
+            prim.impute_nulls(df, "x")  # type: ignore[call-arg]
+
+    def test_unknown_method_raises(self) -> None:
+        df = pd.DataFrame({"x": [1.0, None]})
+        with pytest.raises(ValueError, match="unknown imputation method"):
+            prim.impute_nulls(df, "x", "magic")
+
+    def test_impute_does_not_mutate_input(self) -> None:
+        df = pd.DataFrame({"x": [1.0, None, 3.0]})
+        pristine = df.copy(deep=True)
+        prim.impute_nulls(df, "x", "mean")
+        pd.testing.assert_frame_equal(df, pristine)
+
+    def test_autonomous_path_never_imputes(self) -> None:
+        # Even a null_values finding mis-stamped autonomous yields no imputation.
+        df = pd.DataFrame({"quantity": [1.0, None, None, 4.0]})
+        d = _autonomous("null_values", ["quantity"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert cleaned["quantity"].isna().sum() == 2  # nulls preserved
+        assert not any(
+            a.operation == CleaningOperation.NULL_IMPUTATION for a in result.actions
+        )
+
+
+# --------------------------------------------------------------------------
+# AC 5 — action record provenance
+# --------------------------------------------------------------------------
+class TestActionRecord:
+    def test_result_shape_fields_populated(self, cleaning_dirty_df: pd.DataFrame) -> None:
+        report = DataQualityAssessor().assess_quality(cleaning_dirty_df, RUN_ID).quality_report
+        _, result = CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+        assert result.pipeline_run_id == RUN_ID
+        assert result.rows_before == 12
+        assert result.rows_after == 11  # one duplicate removed
+        assert result.columns_before == result.columns_after == 4
+        assert result.total_findings == 6
+        assert result.autonomous_findings == 4
+
+    def test_every_applied_action_is_traceable(self, cleaning_dirty_df: pd.DataFrame) -> None:
+        report = DataQualityAssessor().assess_quality(cleaning_dirty_df, RUN_ID).quality_report
+        _, result = CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+        applied = [a for a in result.actions if a.status == CleaningStatus.APPLIED]
+        # One per Tier-1 finding: dedup, case, coercion, header.
+        ops = {a.operation for a in applied}
+        assert ops == {
+            CleaningOperation.DEDUPLICATION,
+            CleaningOperation.CASE_NORMALIZATION,
+            CleaningOperation.TYPE_COERCION,
+            CleaningOperation.HEADER_NORMALIZATION,
+        }
+        for a in applied:
+            assert a.remediation_class == RemediationClass.AGENT_AUTONOMOUS
+            assert a.rule  # deterministic rule always stated
+            assert a.detail
+
+    def test_failed_action_carries_safe_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        df = pd.DataFrame({"region": ["a", "A"]})
+        d = _autonomous("case_inconsistency", ["region"])
+
+        def _boom(_series: pd.Series):
+            raise RuntimeError("primitive exploded")
+
+        monkeypatch.setattr(prim, "normalize_case", _boom)
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        # Original preserved; failure captured as a FAILED action with safe info.
+        pd.testing.assert_frame_equal(cleaned, df)
+        failed = [a for a in result.actions if a.status == CleaningStatus.FAILED]
+        assert len(failed) == 1
+        assert failed[0].error is not None and "RuntimeError" in failed[0].error
+
+
+# --------------------------------------------------------------------------
+# AC 6 — determinism & idempotency
+# --------------------------------------------------------------------------
+class TestDeterminismIdempotency:
+    def test_two_runs_identical(self, cleaning_dirty_df: pd.DataFrame) -> None:
+        report = DataQualityAssessor().assess_quality(cleaning_dirty_df, RUN_ID).quality_report
+        c1, r1 = CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+        c2, r2 = CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+        pd.testing.assert_frame_equal(c1, c2)
+        assert r1.model_dump(exclude={"cleaned_at"}) == r2.model_dump(exclude={"cleaned_at"})
+
+    def test_recleaning_output_makes_no_tier1_changes(
+        self, cleaning_dirty_df: pd.DataFrame
+    ) -> None:
+        report = DataQualityAssessor().assess_quality(cleaning_dirty_df, RUN_ID).quality_report
+        cleaned, _ = CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+        # Re-assess the cleaned frame and clean again — no Tier-1 defects remain,
+        # so no autonomous actions and the frame is unchanged.
+        report2 = DataQualityAssessor().assess_quality(cleaned, RUN_ID).quality_report
+        recleaned, result2 = CleaningEngine().clean(cleaned, report2, RUN_ID)
+        applied2 = [a for a in result2.actions if a.status == CleaningStatus.APPLIED]
+        assert applied2 == []
+        pd.testing.assert_frame_equal(recleaned, cleaned)
+
+
+# --------------------------------------------------------------------------
+# AC 8 — integration: assess -> clean -> re-assess
+# --------------------------------------------------------------------------
+class TestIntegration:
+    def test_tier1_gone_tier2_tier3_preserved(self, cleaning_dirty_df: pd.DataFrame) -> None:
+        assessor = DataQualityAssessor()
+        report = assessor.assess_quality(cleaning_dirty_df, RUN_ID).quality_report
+        cleaned, _ = CleaningEngine().clean(cleaning_dirty_df, report, RUN_ID)
+
+        re_report = assessor.assess_quality(cleaned, RUN_ID).quality_report
+        types_after = {d.defect_type for d in re_report.defects}
+
+        # Every Tier-1 defect type is gone.
+        assert "mixed_types" not in types_after
+        assert "case_inconsistency" not in types_after
+        assert "duplicate_rows" not in types_after
+        assert "column_naming" not in types_after
+
+        # Human-owned findings survive: nulls and the negative value untouched.
+        assert "null_values" in types_after
+        assert "negative_values" in types_after
+        assert cleaned["quantity"].isna().sum() == 2
+        assert (cleaned["quantity"] == -5.0).sum() == 1
+
+
+# --------------------------------------------------------------------------
+# small helper
+# --------------------------------------------------------------------------
+def _stub_log():
+    import structlog
+
+    return structlog.get_logger().bind(pipeline_run_id=RUN_ID)

--- a/backend/tests/test_cleaning_engine.py
+++ b/backend/tests/test_cleaning_engine.py
@@ -252,6 +252,19 @@ class TestTypeCoercion:
         cleaned, _ = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
         assert cleaned["code"].isna().sum() == 0
 
+    def test_dominant_type_tie_break_is_deterministic(self) -> None:
+        # Exact 3-vs-3 split between int and numeric-string: value_counts()'s
+        # tie-break can depend on hash/iteration order; ours must not.
+        series = pd.Series([1, 2, 3, "4", "5", "6"], dtype=object)
+        results = {prim.dominant_python_type(series) for _ in range(20)}
+        assert len(results) == 1  # same winner every call, no flapping
+
+    def test_dominant_type_tie_break_matches_qualname_order(self) -> None:
+        # int vs str tie: sorted by (module, qualname) -> ('builtins', 'int')
+        # sorts before ('builtins', 'str').
+        series = pd.Series([1, 2, "a", "b"], dtype=object)
+        assert prim.dominant_python_type(series) is int
+
 
 class TestHeaderNormalization:
     def test_normalizes_special_and_numeric_names(self) -> None:
@@ -262,6 +275,20 @@ class TestHeaderNormalization:
     def test_collision_suffixing_is_deterministic(self) -> None:
         cols, _ = prim.normalize_column_names(["A", "a", "a!"])
         assert cols == ["a", "a_2", "a_3"]
+
+    def test_targets_none_renames_every_column(self) -> None:
+        cols, mapping = prim.normalize_column_names(["Bad Name", "2024"])
+        assert cols == ["bad_name", "column_1"]
+        assert mapping == {"Bad Name": "bad_name", "2024": "column_1"}
+
+    def test_targets_scopes_rename_to_only_named_columns(self) -> None:
+        cols, mapping = prim.normalize_column_names(
+            ["amount#", "Region", "2024"], targets={"amount#"}
+        )
+        # Only "amount#" renamed; "Region" and "2024" pass through untouched
+        # even though "2024" would itself be re-slugged under targets=None.
+        assert cols == ["amount", "Region", "2024"]
+        assert mapping == {"amount#": "amount"}
 
     def test_engine_renames_flagged_headers_in_one_action(self) -> None:
         df = pd.DataFrame({"amount#": [1.0, 2.0], "clean": [3, 4]})
@@ -274,6 +301,48 @@ class TestHeaderNormalization:
         ]
         assert len(header_actions) == 1
         assert header_actions[0].value_mapping == {"amount#": "amount"}
+
+    def test_header_normalization_does_not_touch_unflagged_columns(self) -> None:
+        # "Region" would itself be re-slugged (lowercased) by a blanket rename,
+        # but it carries no column_naming finding — only "amount#" does. Only
+        # the flagged column may change; "Region" must survive byte-identical.
+        df = pd.DataFrame({"amount#": [1.0], "Region": ["north"]})
+        d = _autonomous("column_naming", ["amount#"])
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert list(cleaned.columns) == ["amount", "Region"]
+        header_actions = [
+            a for a in result.actions
+            if a.operation == CleaningOperation.HEADER_NORMALIZATION
+        ]
+        assert header_actions[0].value_mapping == {"amount#": "amount"}
+        assert "Region" not in header_actions[0].value_mapping
+
+    def test_header_normalization_renamed_column_avoids_untouched_collision(self) -> None:
+        # "amount#" slugifies to "amount", which already exists untouched.
+        # Collision detection must still fire even though "amount" itself has
+        # no finding and is never renamed.
+        df = pd.DataFrame({"amount#": [1.0], "amount": [2.0]})
+        d = _autonomous("column_naming", ["amount#"])
+        cleaned, _ = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        assert list(cleaned.columns) == ["amount_2", "amount"]
+
+    def test_header_normalization_failure_degrades_to_failed_action(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        df = pd.DataFrame({"amount#": [1.0]})
+        d = _autonomous("column_naming", ["amount#"])
+
+        def _boom(_columns, targets=None):
+            raise RuntimeError("header primitive exploded")
+
+        monkeypatch.setattr(prim, "normalize_column_names", _boom)
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        # clean() must not raise — the failure degrades to a FAILED action.
+        pd.testing.assert_frame_equal(cleaned, df)
+        failed = [a for a in result.actions if a.status == CleaningStatus.FAILED]
+        assert len(failed) == 1
+        assert failed[0].scope.value == "table"
+        assert "RuntimeError" in failed[0].error
 
 
 # --------------------------------------------------------------------------
@@ -297,6 +366,18 @@ class TestImputationPrimitive:
         df = pd.DataFrame({"x": [1.0, None]})
         with pytest.raises(ValueError, match="unknown imputation method"):
             prim.impute_nulls(df, "x", "magic")
+
+    def test_mean_median_reject_non_numeric_column(self) -> None:
+        df = pd.DataFrame({"x": ["a", None, "c"]})
+        with pytest.raises(ValueError, match="requires a numeric column"):
+            prim.impute_nulls(df, "x", "mean")
+        with pytest.raises(ValueError, match="requires a numeric column"):
+            prim.impute_nulls(df, "x", "median")
+
+    def test_mode_and_forward_fill_accept_non_numeric_column(self) -> None:
+        df = pd.DataFrame({"x": ["a", None, "a"]})
+        assert prim.impute_nulls(df, "x", "mode")["x"].tolist() == ["a", "a", "a"]
+        assert prim.impute_nulls(df, "x", "forward_fill")["x"].tolist() == ["a", "a", "a"]
 
     def test_impute_does_not_mutate_input(self) -> None:
         df = pd.DataFrame({"x": [1.0, None, 3.0]})
@@ -360,6 +441,40 @@ class TestActionRecord:
         failed = [a for a in result.actions if a.status == CleaningStatus.FAILED]
         assert len(failed) == 1
         assert failed[0].error is not None and "RuntimeError" in failed[0].error
+        assert failed[0].scope.value == "column"  # case normalization is column-scoped
+
+    def test_failed_action_scope_matches_the_failed_operation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        df = pd.DataFrame({"a": [1, 1]})
+        d = _autonomous("duplicate_rows", ["a"])
+
+        def _boom(_df: pd.DataFrame):
+            raise RuntimeError("dedup primitive exploded")
+
+        monkeypatch.setattr(prim, "drop_exact_duplicates", _boom)
+        cleaned, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        pd.testing.assert_frame_equal(cleaned, df)
+        failed = [a for a in result.actions if a.status == CleaningStatus.FAILED]
+        assert len(failed) == 1
+        assert failed[0].scope.value == "row"  # NOT the old hardcoded "column"
+
+    def test_failed_action_error_message_is_truncated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        df = pd.DataFrame({"region": ["a", "A"]})
+        d = _autonomous("case_inconsistency", ["region"])
+        long_message = "x" * 5000
+
+        def _boom(_series: pd.Series):
+            raise RuntimeError(long_message)
+
+        monkeypatch.setattr(prim, "normalize_case", _boom)
+        _, result = CleaningEngine().clean(df, _report(df, [d]), RUN_ID)
+        failed = [a for a in result.actions if a.status == CleaningStatus.FAILED]
+        assert len(failed) == 1
+        assert failed[0].error is not None
+        assert len(failed[0].error) < 300
 
 
 # --------------------------------------------------------------------------

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -450,3 +450,71 @@ class TestInsightReport:
         assert '"executive_summary":"Test summary."' in json_str
         restored = InsightReport.model_validate_json(json_str)
         assert restored == report
+
+
+# --- Story 3.2: Cleaning-engine models ------------------------------------
+from backend.models.cleaning_result import (  # noqa: E402
+    CleaningAction,
+    CleaningOperation,
+    CleaningResult,
+    CleaningScope,
+    CleaningStatus,
+)
+
+
+class TestCleaningOperation:
+    def test_values(self) -> None:
+        assert CleaningOperation.DEDUPLICATION.value == "deduplication"
+        assert CleaningOperation.CASE_NORMALIZATION.value == "case_normalization"
+        assert CleaningOperation.TYPE_COERCION.value == "type_coercion"
+        assert CleaningOperation.HEADER_NORMALIZATION.value == "header_normalization"
+        assert CleaningOperation.NULL_IMPUTATION.value == "null_imputation"
+        assert CleaningOperation.NO_OP.value == "no_op"
+
+
+class TestCleaningAction:
+    def test_minimal_construction_defaults(self) -> None:
+        action = CleaningAction(
+            operation=CleaningOperation.DEDUPLICATION,
+            defect_type="duplicate_rows",
+            remediation_class=RemediationClass.AGENT_AUTONOMOUS,
+            status=CleaningStatus.APPLIED,
+            scope=CleaningScope.ROW,
+        )
+        assert action.target_columns == []
+        assert action.rows_affected == 0
+        assert action.values_changed == 0
+        assert action.value_mapping == {}
+        assert action.parameters == {}
+        assert action.error is None
+
+    def test_roundtrip_json(self) -> None:
+        action = CleaningAction(
+            operation=CleaningOperation.CASE_NORMALIZATION,
+            defect_type="case_inconsistency",
+            remediation_class=RemediationClass.AGENT_AUTONOMOUS,
+            status=CleaningStatus.APPLIED,
+            scope=CleaningScope.COLUMN,
+            target_columns=["region"],
+            values_changed=2,
+            value_mapping={"North": "north"},
+        )
+        restored = CleaningAction.model_validate_json(action.model_dump_json())
+        assert restored == action
+
+
+class TestCleaningResult:
+    def test_construction(self) -> None:
+        result = CleaningResult(
+            pipeline_run_id="r1",
+            total_findings=3,
+            autonomous_findings=1,
+            actions=[],
+            rows_before=10,
+            rows_after=9,
+            columns_before=4,
+            columns_after=4,
+            cleaned_at="2026-07-20T00:00:00+00:00",
+        )
+        assert result.actions == []
+        assert result.rows_before == 10 and result.rows_after == 9


### PR DESCRIPTION
Implements [Story 3.2](https://github.com/marvinmckinneyii0/savvy-cleanse-analysis/blob/story/3-2-impl-cleaning-engine/_bmad-output/implementation-artifacts/3-2-cleaning-engine-core.md) — the deterministic Cleaning Engine core. **The first code path in SAINT that modifies data**, so every guard here is load-bearing: a bug is not a wrong number in a report, it is silent mutation of a client's data.

## Summary

Applies the four Tier-1 rules-based remediations to a **working copy** of the input, acting autonomously **only** on findings the Story 3.1 classifier stamped `agent_autonomous`, and returns `(cleaned_df, CleaningResult)` — the cleaned copy plus a full provenance record. Classification decides *whether* a finding may be touched; this engine decides *how*. Nothing is wired into the pipeline yet.

## Architecture & safety invariants

- **Working-copy only.** Deep copy at the public entry point; the caller's DataFrame is never mutated on any path (verified by `assert_frame_equal` against a pristine copy after cleaning a maximally-dirty fixture).
- **Tier-1-only, fail-closed twice.** Public `clean()` filters to `AGENT_AUTONOMOUS`; the private per-finding dispatch (`_apply_operation`, `_normalize_headers`) independently re-checks and raises `CleaningEngineError` on any non-autonomous finding. No flag, param, or env var widens this.
- **Unknown / unsupported `defect_type` fails closed.** Default-classed (`human_only`) findings are filtered out; an autonomous finding with no registered operation produces a visible `SKIPPED`/`NO_OP` record and **zero** data change (surfaces classifier/engine drift without acting).
- **Human-owned findings never touched.** Tier-2 (`null_values`) and Tier-3 (`negative_values`, outliers, …) pass through untouched — asserted end-to-end.
- **Keyed on `defect_type`, never `category`** (mirroring 3.1) so a future Tier-3 variant can't inherit an autonomous class.
- **Deterministic & idempotent.** Fixed processing order (coercion → case → dedup → header-last); two runs on the same input are byte-identical; re-cleaning cleaned output makes no further Tier-1 changes.
- **structlog** events carry `pipeline_run_id` and log counts/column names only — never raw row data or PII.

## Supported Tier-1 operations (keyed on `defect_type`)

| `defect_type` | Operation | Deterministic rule |
|---|---|---|
| `duplicate_rows` | deduplication | drop exact duplicates, keep first, preserve order |
| `case_inconsistency` | case normalization | collapse variants to most-frequent original; tie → lexicographically smallest |
| `mixed_types` | type coercion | strip whitespace, coerce to dominant type; **uncoercible values preserved, never nulled**; datetime-dominant → ISO-8601 |
| `column_naming` | header normalization | snake_case slug; empty/numeric → `column_{i}`; collisions suffixed `_2`, `_3`, … |

## Imputation boundary

`impute_nulls(df, column, method)` ships as a **policy-less primitive**: `method` is mandatory (no default), it is **not** in the operation registry, and it is **unreachable from the autonomous path**. It is the execution seam Story 3.4's Tier-2 policy layer will call. A `null_values` finding — even one mis-stamped autonomous — yields zero imputation.

## Result contract

`CleaningAction` / `CleaningResult` (`backend/models/cleaning_result.py`) are the **single source Story 3.3 renders the healing manifest from** — defect_type, operation, scope, target columns, before/after state, rows/values changed, value_mapping, deterministic rule, remediation_class, status (`applied`/`skipped`/`failed`), and safe error info. No parallel manifest format was introduced.

## Explicit exclusions (deferred by design)

- **No orchestrator/CLI wiring** — cleaning is opt-in/default-off; the gate that makes wiring safe is **Story 3.4**. Wiring now would ship always-on cleaning.
- No imputation **defaults** (3.4), no Healing Manifest artifact (3.3), no Tier-3 scoring (3.5), no export (3.6), no client-facing copy (3.9), no `backend/rules/` (3.4), no new DQA detectors.

## Legacy `backend/cleaner.py` decision

Left **behaviorally untouched**. It delegates to the legacy `advanced_pipeline.DataCleaner` (on the project-context legacy list) and has no tests — it is **not** the deterministic engine. Added a STATUS header marking it legacy and pointing to `cleaning_engine.py`; not imported, extended, or deleted.

## Test results

- **Backend: 268 passed / 1 skipped** (optional `anthropic` SDK) **/ 0 regressions.** 67 new tests: working-copy invariant, fail-closed dispatch (incl. the `CleaningEngineError` guard), per-operation specs (tie-breaks, collision suffixes, uncoercible-preservation), imputation boundary, action-record provenance, determinism/idempotency, and an assess→clean→re-assess integration pass (Tier-1 types gone, Tier-2/3 preserved).
- Frontend unaffected: vitest **18/18**; vite build OK.
- `/security-review`: **no Critical/High** — pure in-memory transforms, no external attack surface.

## Deviations from the story spec

None material. Additive-only refinements for manifest fidelity: a `NO_OP` operation + `SKIPPED`/`FAILED` statuses and a `CleaningScope` field beyond the story's minimal enum list. Primitives live in a dedicated `cleaning_primitives.py` (pure) separate from the engine so 3.4 can import `impute_nulls` without the autonomous engine.

Sprint status: `3-2-cleaning-engine-core` → `review` (not marked done until review + CI pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)