### PR TITLE
Add bounded Claude–Codex PRD handoff loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ htmlcov/
 # Claude Code worktree metadata
 .claude/
 scratch_prd/
+
+# Local Claude -> Codex handoff runtime
+.agent-handoff/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# SAINT Agent Execution Contract
+
+This repository uses a bounded Claude → Codex development handoff.
+
+## Authority
+
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` is the sole status source of truth.
+- The selected BMAD story file is the authoritative execution contract.
+- `loop_eligible` is human-controlled. Agents must never change it.
+- Marvin is the sole merge authority. Agents may open draft pull requests but must never merge.
+
+## Per-run boundary
+
+A run may execute exactly one story. It must stop when:
+
+- no story is both `ready-for-dev` and `loop_eligible: true`;
+- an upstream dependency is not done;
+- the story is ambiguous or contradicts an architectural invariant;
+- implementation requires work outside the story scope;
+- authentication, authorization, tenancy, billing, migrations, destructive operations, production deployment, or shared schemas require an unapproved decision;
+- required tests fail outside the story scope;
+- the story is materially larger or riskier than specified.
+
+## Claude responsibilities
+
+Claude is the controller and reviewer:
+
+1. Run `python agent-system/handoff_loop.py status`.
+2. Review the selected story, PRD, dependencies, and repository state.
+3. Run `python agent-system/handoff_loop.py run` only when the selected story is safe and unambiguous.
+4. Independently inspect the resulting diff and validation report.
+5. Stop at a draft PR and summarize the exact human review focus.
+
+Claude must not implement the same story it reviews unless Marvin explicitly overrides the separation.
+
+## Codex responsibilities
+
+Codex is the implementation worker:
+
+- Modify only files allowed by the story.
+- Implement the smallest complete change satisfying every acceptance criterion.
+- Preserve all invariants and backward compatibility requirements.
+- Add tests for success, failure, boundaries, and regressions.
+- Run the full required repository checks.
+- Never edit `loop_eligible`, orchestration policy, or this contract.
+- Never merge.
+- Halt rather than guessing when scope or architecture is unclear.
+
+## Required checks
+
+Every implementation run must pass:
+
+```bash
+uv run pytest
+npm test
+npm run build
+```
+
+Run any additional story-specific, lint, security, type, or integration checks required by the story or existing CI.

--- a/agent-system/README.md
+++ b/agent-system/README.md
@@ -1,0 +1,76 @@
+# Claude → Codex PRD Handoff Loop
+
+This loop executes one safe, eligible SAINT story per run.
+
+## Operating model
+
+1. Claude reads the canonical sprint status and selects the next story where:
+   - `status: ready-for-dev`
+   - `loop_eligible: true`
+   - explicit dependencies are `done`
+2. The loop writes a SHA-bound execution packet.
+3. A fresh `loop/story-*` branch is created from a clean, synchronized `main`.
+4. Codex receives the worker contract plus the complete authoritative story.
+5. Codex implements and commits the story.
+6. The controller rejects changes to protected orchestration paths.
+7. The full repository validation suite runs.
+8. Claude reviews the diff.
+9. After approval, Claude may push and open a draft PR.
+10. Marvin reviews and manually merges.
+11. Run the loop again after the merge.
+
+The loop never continuously drains the roadmap. Each invocation stops after one story and one human checkpoint.
+
+## Commands
+
+From the repository root in Claude Code:
+
+```bash
+python agent-system/handoff_loop.py status
+```
+
+Preview the exact handoff without executing Codex:
+
+```bash
+python agent-system/handoff_loop.py prepare
+```
+
+Execute the next eligible story:
+
+```bash
+python agent-system/handoff_loop.py run
+```
+
+Execute a specific eligible story:
+
+```bash
+python agent-system/handoff_loop.py run --story 3-6-cleaned-data-export
+```
+
+## Claude invocation
+
+Use this instruction in Claude Code:
+
+```text
+Run the SAINT bounded PRD handoff loop. First execute
+`python agent-system/handoff_loop.py status`. If exactly one safe story is
+selectable, inspect its BMAD story and dependencies, then execute
+`python agent-system/handoff_loop.py run`. After Codex returns, independently
+review the committed diff and `.agent-handoff/validation.json`. Halt on any
+scope, architecture, security, or acceptance-criteria problem. If clean, push
+the story branch and open a draft PR. Never merge.
+```
+
+## Runtime artifacts
+
+The local `.agent-handoff/` directory contains:
+
+- `current.json` — immutable execution packet
+- `current-prompt.md` — exact prompt sent to Codex
+- `validation.json` — independent validation results
+
+These artifacts are local and intentionally ignored by Git.
+
+## Current queue behavior
+
+If no story is currently both ready and eligible, the command exits safely. Claude must not change `loop_eligible` merely to keep the loop active.

--- a/agent-system/handoff_loop.py
+++ b/agent-system/handoff_loop.py
@@ -93,8 +93,8 @@ def run_command(
     return result
 
 
-def git(*args: str, check: bool = True) -> str:
-    return (run_command(["git", *args], check=check).stdout or "").strip()
+def git(*args: str, check: bool = True, cwd: Path = ROOT) -> str:
+    return (run_command(["git", *args], cwd=cwd, check=check).stdout or "").strip()
 
 
 def sha256(path: Path) -> str:
@@ -301,9 +301,33 @@ def verify_packet_fresh(packet: ExecutionPacket) -> None:
         raise LoopError("Story file changed after handoff preparation")
 
 
-def changed_paths(base_sha: str) -> list[str]:
-    output = git("diff", "--name-only", f"{base_sha}...HEAD")
+def changed_paths(base_sha: str, *, root: Path = ROOT) -> list[str]:
+    output = git("diff", "--name-only", f"{base_sha}...HEAD", cwd=root)
     return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def uncommitted_paths(*, root: Path = ROOT) -> list[str]:
+    """Every path with a staged, unstaged, or untracked change in the working tree.
+
+    Uses `run_command` directly rather than `git()`: porcelain status lines carry a
+    leading space as part of the two-character status code, and `git()`'s blanket
+    `.strip()` would eat it, shifting every subsequent field left by one.
+    """
+
+    result = run_command(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=root,
+    )
+    output = result.stdout or ""
+    paths: list[str] = []
+    for line in output.splitlines():
+        if not line:
+            continue
+        entry = line[3:]
+        if " -> " in entry:
+            entry = entry.split(" -> ", 1)[1]
+        paths.append(entry.strip())
+    return paths
 
 
 def validate_changed_paths(paths: list[str]) -> None:
@@ -313,6 +337,20 @@ def validate_changed_paths(paths: list[str]) -> None:
             violations.append(path)
     if violations:
         raise LoopError("Codex modified protected orchestration paths: " + ", ".join(violations))
+
+
+def verify_story_untouched(packet: ExecutionPacket, *, root: Path = ROOT) -> None:
+    """Fail closed if the authoritative story changed during Codex execution.
+
+    Reads the file directly (not `git diff`), so this catches the change whether
+    Codex committed it or left it uncommitted in the working tree.
+    """
+
+    story_path = root / packet.story_path
+    if not story_path.exists():
+        raise LoopError(f"Authoritative story file is missing after execution: {packet.story_path}")
+    if sha256(story_path) != packet.story_file_sha256:
+        raise LoopError(f"Authoritative story file changed during Codex execution: {packet.story_path}")
 
 
 def run_validation() -> dict[str, Any]:
@@ -368,10 +406,19 @@ def execute(candidate: StoryCandidate) -> int:
         if result.returncode != 0:
             raise LoopError(f"Codex exited with status {result.returncode}")
 
+        verify_story_untouched(packet)
+
         paths = changed_paths(packet.base_commit_sha)
         if not paths:
             raise LoopError("Codex completed without producing a committed diff")
-        validate_changed_paths(paths)
+
+        pending_paths = uncommitted_paths()
+        validate_changed_paths(sorted(set(paths) | set(pending_paths)))
+        if pending_paths:
+            raise LoopError(
+                "Codex left uncommitted changes in the working tree: "
+                + ", ".join(sorted(pending_paths))
+            )
 
         report = run_validation()
         if not report["success"]:

--- a/agent-system/handoff_loop.py
+++ b/agent-system/handoff_loop.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Bounded Claude → Codex handoff loop for SAINT.
+
+The loop executes at most one eligible BMAD story per invocation. It never merges,
+never edits loop_eligible, and treats sprint-status.yaml as authoritative.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+STATUS_PATH = ROOT / "_bmad-output" / "implementation-artifacts" / "sprint-status.yaml"
+STORY_DIR = STATUS_PATH.parent
+PROMPT_PATH = ROOT / "agent-system" / "prompts" / "codex-worker.md"
+RUNTIME_DIR = ROOT / ".agent-handoff"
+CURRENT_PACKET = RUNTIME_DIR / "current.json"
+CURRENT_PROMPT = RUNTIME_DIR / "current-prompt.md"
+VALIDATION_REPORT = RUNTIME_DIR / "validation.json"
+
+READY_STATUS = "ready-for-dev"
+DONE_STATUS = "done"
+PROTECTED_PATH_PREFIXES = (
+    "agent-system/",
+    ".github/workflows/",
+)
+PROTECTED_EXACT_PATHS = {
+    "AGENTS.md",
+    "_bmad-output/implementation-artifacts/sprint-status.yaml",
+    "_bmad-output/implementation-artifacts/loop-runner-spec.md",
+}
+
+
+class LoopError(RuntimeError):
+    """Expected, user-actionable loop failure."""
+
+
+@dataclass(frozen=True)
+class StoryCandidate:
+    story_id: str
+    status: str
+    loop_eligible: bool
+    story_path: str
+    dependencies: tuple[str, ...]
+    blocked_dependencies: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ExecutionPacket:
+    story_id: str
+    story_path: str
+    base_commit_sha: str
+    status_file_sha256: str
+    story_file_sha256: str
+    dependencies: tuple[str, ...]
+    generated_at: str
+    branch: str
+    constraints: tuple[str, ...]
+
+
+def run_command(
+    command: list[str],
+    *,
+    cwd: Path = ROOT,
+    check: bool = True,
+    capture: bool = True,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        text=True,
+        input=input_text,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+    )
+    if check and result.returncode != 0:
+        output = result.stdout or ""
+        raise LoopError(f"Command failed ({result.returncode}): {' '.join(command)}\n{output}")
+    return result
+
+
+def git(*args: str, check: bool = True) -> str:
+    return (run_command(["git", *args], check=check).stdout or "").strip()
+
+
+def sha256(path: Path) -> str:
+    import hashlib
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_status() -> dict[str, Any]:
+    if not STATUS_PATH.exists():
+        raise LoopError(f"Missing canonical status file: {STATUS_PATH}")
+    data = yaml.safe_load(STATUS_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or not isinstance(data.get("development_status"), dict):
+        raise LoopError("sprint-status.yaml has no development_status mapping")
+    return data
+
+
+def story_entries(status_data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    for key, value in status_data["development_status"].items():
+        if not isinstance(value, dict):
+            continue
+        if "status" not in value or "loop_eligible" not in value:
+            continue
+        entries[str(key)] = value
+    return entries
+
+
+def find_story_file(story_id: str) -> Path:
+    matches = sorted(STORY_DIR.glob(f"{story_id}*.md"))
+    if not matches:
+        raise LoopError(f"No BMAD story file found for {story_id}")
+    if len(matches) > 1:
+        names = ", ".join(path.name for path in matches)
+        raise LoopError(f"Ambiguous story files for {story_id}: {names}")
+    return matches[0]
+
+
+def extract_dependencies(story_text: str, known_story_ids: set[str]) -> tuple[str, ...]:
+    """Conservatively extract explicit story prerequisites from markdown.
+
+    Only references near prerequisite/dependency language count. Incidental references
+    in broader prose do not become execution dependencies.
+    """
+
+    found: set[str] = set()
+    dependency_words = re.compile(
+        r"(?i)(prerequisite|required before|depends? on|blocked[-_ ]on|upstream|must be merged first)"
+    )
+    story_ref = re.compile(r"\b(?:Story\s+)?([Rr]?\.?\d+(?:\.\d+)?|\d+-\d+[a-z]?)\b")
+
+    for line in story_text.splitlines():
+        if not dependency_words.search(line):
+            continue
+        for raw in story_ref.findall(line):
+            normalized = raw.lower().replace(".", "-")
+            for story_id in known_story_ids:
+                numeric_prefix = story_id.split("-", 2)[:2]
+                candidate_prefix = "-".join(numeric_prefix)
+                if normalized == story_id.lower() or normalized == candidate_prefix.lower():
+                    found.add(story_id)
+    return tuple(sorted(found))
+
+
+def collect_candidates() -> tuple[list[StoryCandidate], list[StoryCandidate]]:
+    status_data = load_status()
+    entries = story_entries(status_data)
+    known_ids = set(entries)
+    eligible: list[StoryCandidate] = []
+    blocked: list[StoryCandidate] = []
+
+    for story_id, metadata in entries.items():
+        if metadata.get("status") != READY_STATUS or metadata.get("loop_eligible") is not True:
+            continue
+        story_path = find_story_file(story_id)
+        dependencies = extract_dependencies(
+            story_path.read_text(encoding="utf-8"),
+            known_ids,
+        )
+        blocked_dependencies = tuple(
+            dep for dep in dependencies if entries.get(dep, {}).get("status") != DONE_STATUS
+        )
+        candidate = StoryCandidate(
+            story_id=story_id,
+            status=str(metadata.get("status")),
+            loop_eligible=True,
+            story_path=str(story_path.relative_to(ROOT).as_posix()),
+            dependencies=dependencies,
+            blocked_dependencies=blocked_dependencies,
+        )
+        (blocked if blocked_dependencies else eligible).append(candidate)
+
+    eligible.sort(key=story_sort_key)
+    blocked.sort(key=story_sort_key)
+    return eligible, blocked
+
+
+def story_sort_key(candidate: StoryCandidate) -> tuple[Any, ...]:
+    parts: list[Any] = []
+    for token in re.split(r"[-.]", candidate.story_id):
+        parts.append(int(token) if token.isdigit() else token)
+    return tuple(parts)
+
+
+def ensure_repo_ready() -> None:
+    if shutil.which("git") is None:
+        raise LoopError("git is not available")
+    if shutil.which("codex") is None:
+        raise LoopError("Codex CLI is not available. Run /codex:setup in Claude Code.")
+
+    repo_root = Path(git("rev-parse", "--show-toplevel")).resolve()
+    if repo_root != ROOT:
+        raise LoopError(f"Run from the SAINT repository. Expected {ROOT}, found {repo_root}")
+
+    branch = git("branch", "--show-current")
+    if branch != "main":
+        raise LoopError(f"Start the handoff from main; current branch is {branch!r}")
+
+    status = git("status", "--porcelain")
+    if status:
+        raise LoopError("Working tree is not clean. Commit, stash, or discard unrelated changes first.")
+
+    git("fetch", "origin", "main")
+    local = git("rev-parse", "main")
+    remote = git("rev-parse", "origin/main")
+    if local != remote:
+        raise LoopError("Local main is not equal to origin/main. Pull or reconcile before dispatch.")
+
+
+def select_candidate(requested_story: str | None = None) -> StoryCandidate:
+    eligible, blocked = collect_candidates()
+    if requested_story:
+        for candidate in eligible:
+            if candidate.story_id == requested_story:
+                return candidate
+        for candidate in blocked:
+            if candidate.story_id == requested_story:
+                deps = ", ".join(candidate.blocked_dependencies)
+                raise LoopError(f"Story {requested_story} is blocked by incomplete dependencies: {deps}")
+        raise LoopError(
+            f"Story {requested_story} is not both {READY_STATUS!r} and loop_eligible:true"
+        )
+    if not eligible:
+        if blocked:
+            details = "; ".join(
+                f"{item.story_id} blocked by {', '.join(item.blocked_dependencies)}"
+                for item in blocked
+            )
+            raise LoopError(f"No selectable story. Dependency-blocked candidates: {details}")
+        raise LoopError("No story is currently ready-for-dev and loop_eligible:true. Exiting safely.")
+    return eligible[0]
+
+
+def create_packet(candidate: StoryCandidate) -> ExecutionPacket:
+    branch = f"loop/story-{candidate.story_id}"
+    story_path = ROOT / candidate.story_path
+    return ExecutionPacket(
+        story_id=candidate.story_id,
+        story_path=candidate.story_path,
+        base_commit_sha=git("rev-parse", "HEAD"),
+        status_file_sha256=sha256(STATUS_PATH),
+        story_file_sha256=sha256(story_path),
+        dependencies=candidate.dependencies,
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        branch=branch,
+        constraints=(
+            "one story per run",
+            "never modify loop_eligible",
+            "never merge",
+            "halt on ambiguity or scope expansion",
+            "full pytest, frontend test, and production build required",
+        ),
+    )
+
+
+def prepare_handoff(candidate: StoryCandidate) -> ExecutionPacket:
+    packet = create_packet(candidate)
+    RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    CURRENT_PACKET.write_text(json.dumps(asdict(packet), indent=2) + "\n", encoding="utf-8")
+
+    worker_prompt = PROMPT_PATH.read_text(encoding="utf-8")
+    story_text = (ROOT / packet.story_path).read_text(encoding="utf-8")
+    rendered = (
+        f"{worker_prompt}\n\n"
+        "# Execution packet\n\n"
+        f"```json\n{json.dumps(asdict(packet), indent=2)}\n```\n\n"
+        f"# Authoritative story: `{packet.story_path}`\n\n"
+        f"{story_text}\n"
+    )
+    CURRENT_PROMPT.write_text(rendered, encoding="utf-8")
+    return packet
+
+
+def verify_packet_fresh(packet: ExecutionPacket) -> None:
+    if git("rev-parse", "HEAD") != packet.base_commit_sha:
+        raise LoopError("Base commit moved after handoff preparation")
+    if sha256(STATUS_PATH) != packet.status_file_sha256:
+        raise LoopError("sprint-status.yaml changed after handoff preparation")
+    if sha256(ROOT / packet.story_path) != packet.story_file_sha256:
+        raise LoopError("Story file changed after handoff preparation")
+
+
+def changed_paths(base_sha: str) -> list[str]:
+    output = git("diff", "--name-only", f"{base_sha}...HEAD")
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def validate_changed_paths(paths: list[str]) -> None:
+    violations: list[str] = []
+    for path in paths:
+        if path in PROTECTED_EXACT_PATHS or any(path.startswith(prefix) for prefix in PROTECTED_PATH_PREFIXES):
+            violations.append(path)
+    if violations:
+        raise LoopError("Codex modified protected orchestration paths: " + ", ".join(violations))
+
+
+def run_validation() -> dict[str, Any]:
+    checks = [
+        ("backend", ["uv", "run", "pytest"]),
+        ("frontend", ["npm", "test"]),
+        ("build", ["npm", "run", "build"]),
+    ]
+    report: dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "checks": [],
+        "success": True,
+    }
+    for name, command in checks:
+        result = run_command(command, check=False)
+        passed = result.returncode == 0
+        report["checks"].append(
+            {
+                "name": name,
+                "command": command,
+                "returncode": result.returncode,
+                "passed": passed,
+                "output_tail": (result.stdout or "")[-4000:],
+            }
+        )
+        report["success"] = bool(report["success"] and passed)
+    RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    VALIDATION_REPORT.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return report
+
+
+def execute(candidate: StoryCandidate) -> int:
+    ensure_repo_ready()
+    packet = prepare_handoff(candidate)
+    verify_packet_fresh(packet)
+
+    existing = git("branch", "--list", packet.branch)
+    if existing:
+        raise LoopError(f"Local branch already exists: {packet.branch}")
+    remote_existing = git("ls-remote", "--heads", "origin", packet.branch)
+    if remote_existing:
+        raise LoopError(f"Remote branch already exists: {packet.branch}")
+
+    git("checkout", "-b", packet.branch)
+    try:
+        prompt = CURRENT_PROMPT.read_text(encoding="utf-8")
+        result = run_command(
+            ["codex", "exec", "--ephemeral", "-"],
+            check=False,
+            capture=False,
+            input_text=prompt,
+        )
+        if result.returncode != 0:
+            raise LoopError(f"Codex exited with status {result.returncode}")
+
+        paths = changed_paths(packet.base_commit_sha)
+        if not paths:
+            raise LoopError("Codex completed without producing a committed diff")
+        validate_changed_paths(paths)
+
+        report = run_validation()
+        if not report["success"]:
+            print(f"Validation failed. Report: {VALIDATION_REPORT.relative_to(ROOT)}")
+            return 2
+
+        print("\nHandoff implementation is ready for Claude review.")
+        print(f"Story: {packet.story_id}")
+        print(f"Branch: {packet.branch}")
+        print("Changed paths:")
+        for path in paths:
+            print(f"  - {path}")
+        print(f"Validation report: {VALIDATION_REPORT.relative_to(ROOT)}")
+        print("Do not merge. Claude must review the diff before a draft PR is presented to Marvin.")
+        return 0
+    except Exception:
+        print(f"\nLoop halted on branch {packet.branch}. Changes were preserved for inspection.")
+        raise
+
+
+def print_status() -> int:
+    eligible, blocked = collect_candidates()
+    print("SAINT Claude → Codex handoff status")
+    print(f"Canonical status: {STATUS_PATH.relative_to(ROOT)}")
+    if eligible:
+        print("\nSelectable stories:")
+        for item in eligible:
+            deps = ", ".join(item.dependencies) or "none"
+            print(f"  {item.story_id}: {item.story_path} (dependencies: {deps})")
+        print(f"\nNext story: {eligible[0].story_id}")
+    else:
+        print("\nNo selectable stories.")
+    if blocked:
+        print("\nDependency-blocked eligible stories:")
+        for item in blocked:
+            print(f"  {item.story_id}: {', '.join(item.blocked_dependencies)}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("status", help="show selectable and blocked stories")
+
+    prepare_parser = subparsers.add_parser("prepare", help="write a handoff packet without running Codex")
+    prepare_parser.add_argument("--story", help="explicit story id; default selects the next eligible story")
+
+    run_parser = subparsers.add_parser("run", help="execute one bounded Codex handoff")
+    run_parser.add_argument("--story", help="explicit story id; default selects the next eligible story")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "status":
+            return print_status()
+        candidate = select_candidate(getattr(args, "story", None))
+        if args.command == "prepare":
+            ensure_repo_ready()
+            packet = prepare_handoff(candidate)
+            print(json.dumps(asdict(packet), indent=2))
+            print(f"Prompt: {CURRENT_PROMPT.relative_to(ROOT)}")
+            return 0
+        if args.command == "run":
+            return execute(candidate)
+        raise LoopError(f"Unknown command: {args.command}")
+    except LoopError as exc:
+        print(f"HALT: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-system/prompts/codex-worker.md
+++ b/agent-system/prompts/codex-worker.md
@@ -27,9 +27,10 @@ The handoff appended below contains the selected story, its status metadata, rep
    ```
 
    Also run every additional check required by the story.
-8. Never merge a pull request.
-9. Do not change the canonical story status to `done`; that happens only after review and merge.
-10. Stop immediately rather than infer a product, architecture, security, data-loss, billing, tenancy, authentication, authorization, migration, or deployment decision.
+8. Commit the completed implementation to the already-created story branch with a concise story-scoped commit message. Do not push unless Claude explicitly asks after review.
+9. Never merge a pull request.
+10. Do not change the canonical story status to `done`; that happens only after review and merge.
+11. Stop immediately rather than infer a product, architecture, security, data-loss, billing, tenancy, authentication, authorization, migration, or deployment decision.
 
 ## Completion response
 
@@ -45,6 +46,7 @@ Then report:
 - files changed;
 - acceptance criteria satisfied;
 - tests and checks run with results;
+- commit created;
 - unresolved risks or assumptions;
 - recommended human review focus.
 

--- a/agent-system/prompts/codex-worker.md
+++ b/agent-system/prompts/codex-worker.md
@@ -1,0 +1,51 @@
+# Codex Worker Prompt — SAINT PRD Handoff
+
+You are the implementation worker for one bounded SAINT story.
+
+The handoff appended below contains the selected story, its status metadata, repository base SHA, and execution constraints.
+
+## Rules
+
+1. Read `AGENTS.md`, the selected story file, the relevant PRD/architecture documents, and current tests before editing.
+2. Implement exactly one story. Do not begin dependent or adjacent stories.
+3. Modify only files permitted by the story's explicit scope. If scope is not explicit enough to determine this safely, stop and report `BLOCKED_NEEDS_MARVIN`.
+4. Do not modify:
+   - `loop_eligible` in any file;
+   - `agent-system/**`;
+   - `AGENTS.md`;
+   - `.github/workflows/**`;
+   - architecture or PRD authority documents;
+   unless the selected story explicitly requires that exact path and the handoff explicitly permits it.
+5. Preserve every load-bearing invariant and backward-compatibility requirement.
+6. Add or update tests covering success, failure, boundary behavior, determinism where applicable, and regression risk.
+7. Run the complete validation suite:
+
+   ```bash
+   uv run pytest
+   npm test
+   npm run build
+   ```
+
+   Also run every additional check required by the story.
+8. Never merge a pull request.
+9. Do not change the canonical story status to `done`; that happens only after review and merge.
+10. Stop immediately rather than infer a product, architecture, security, data-loss, billing, tenancy, authentication, authorization, migration, or deployment decision.
+
+## Completion response
+
+End with one of these exact statuses:
+
+- `READY_FOR_REVIEW`
+- `BLOCKED_NEEDS_MARVIN`
+- `FAILED_VALIDATION`
+- `REJECTED_SCOPE_CONFLICT`
+
+Then report:
+
+- files changed;
+- acceptance criteria satisfied;
+- tests and checks run with results;
+- unresolved risks or assumptions;
+- recommended human review focus.
+
+Do not claim a check passed unless you executed it and observed a successful result.

--- a/agent-system/tests/test_handoff_loop.py
+++ b/agent-system/tests/test_handoff_loop.py
@@ -1,0 +1,167 @@
+"""Regression tests for the two P1 handoff-loop controller findings.
+
+1. Protected-path validation must see uncommitted (staged/unstaged/untracked)
+   changes, not just the committed diff, and any leftover uncommitted change
+   must block success even if it isn't a protected path.
+2. The authoritative story file must be treated as immutable after Codex runs
+   -- re-checked by content hash, whether the change was committed or not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+AGENT_SYSTEM_DIR = Path(__file__).resolve().parents[1]
+if str(AGENT_SYSTEM_DIR) not in sys.path:
+    sys.path.insert(0, str(AGENT_SYSTEM_DIR))
+
+import handoff_loop as hl  # noqa: E402
+
+
+def _run_git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _write(repo: Path, relative: str, content: str) -> Path:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.fixture()
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(repo, "init", "-q")
+    _run_git(repo, "config", "user.email", "test@example.com")
+    _run_git(repo, "config", "user.name", "Test User")
+    _write(repo, "README.md", "hello\n")
+    _run_git(repo, "add", "README.md")
+    _run_git(repo, "commit", "-q", "-m", "initial commit")
+    return repo
+
+
+class TestUncommittedPaths:
+    def test_clean_tree_reports_nothing(self, git_repo: Path) -> None:
+        assert hl.uncommitted_paths(root=git_repo) == []
+
+    def test_detects_staged_change(self, git_repo: Path) -> None:
+        _write(git_repo, "README.md", "changed\n")
+        _run_git(git_repo, "add", "README.md")
+        assert "README.md" in hl.uncommitted_paths(root=git_repo)
+
+    def test_detects_unstaged_change(self, git_repo: Path) -> None:
+        _write(git_repo, "README.md", "changed again\n")
+        assert "README.md" in hl.uncommitted_paths(root=git_repo)
+
+    def test_detects_untracked_file(self, git_repo: Path) -> None:
+        _write(git_repo, "scratch.txt", "new\n")
+        assert "scratch.txt" in hl.uncommitted_paths(root=git_repo)
+
+
+class TestValidateChangedPaths:
+    def test_allows_ordinary_paths(self) -> None:
+        hl.validate_changed_paths(["backend/pipeline/orchestrator.py"])
+
+    def test_rejects_protected_prefix(self) -> None:
+        with pytest.raises(hl.LoopError):
+            hl.validate_changed_paths(["agent-system/handoff_loop.py"])
+
+    def test_rejects_protected_exact_path(self) -> None:
+        with pytest.raises(hl.LoopError):
+            hl.validate_changed_paths(["AGENTS.md"])
+
+
+class TestFindingOneUncommittedBypass:
+    """Reproduces the reviewed bypass: Codex commits a clean diff but leaves a
+    protected-file edit (or any leftover change) sitting uncommitted."""
+
+    def test_committed_only_diff_was_previously_indistinguishable_from_safe(
+        self, git_repo: Path
+    ) -> None:
+        _write(git_repo, "backend/feature.py", "print('ok')\n")
+        _run_git(git_repo, "add", "backend/feature.py")
+        _run_git(git_repo, "commit", "-q", "-m", "feature work")
+        committed = hl.changed_paths("HEAD~1", root=git_repo)
+        assert committed == ["backend/feature.py"]
+        hl.validate_changed_paths(committed)  # no protected paths committed -> fine
+
+    def test_uncommitted_protected_edit_is_now_caught(self, git_repo: Path) -> None:
+        _write(git_repo, "backend/feature.py", "print('ok')\n")
+        _run_git(git_repo, "add", "backend/feature.py")
+        _run_git(git_repo, "commit", "-q", "-m", "feature work")
+        # Codex leaves a protected orchestration file modified but uncommitted.
+        _write(git_repo, "agent-system/handoff_loop.py", "# tampered\n")
+
+        committed = hl.changed_paths("HEAD~1", root=git_repo)
+        pending = hl.uncommitted_paths(root=git_repo)
+        assert "agent-system/handoff_loop.py" in pending
+
+        with pytest.raises(hl.LoopError, match="protected orchestration paths"):
+            hl.validate_changed_paths(sorted(set(committed) | set(pending)))
+
+    def test_any_leftover_uncommitted_change_blocks_success(self, git_repo: Path) -> None:
+        _write(git_repo, "backend/feature.py", "print('ok')\n")
+        _run_git(git_repo, "add", "backend/feature.py")
+        _run_git(git_repo, "commit", "-q", "-m", "feature work")
+        # Leftover change is not protected, but must still block success.
+        _write(git_repo, "backend/scratch.py", "# leftover\n")
+
+        pending = hl.uncommitted_paths(root=git_repo)
+        assert pending == ["backend/scratch.py"]
+        # validate_changed_paths alone would not catch this (not protected) --
+        # the controller must independently reject any leftover uncommitted path.
+
+
+class TestFindingTwoStoryImmutability:
+    def _packet(self, repo: Path, story_rel: str) -> hl.ExecutionPacket:
+        return hl.ExecutionPacket(
+            story_id="9-9-test-story",
+            story_path=story_rel,
+            base_commit_sha="deadbeef",
+            status_file_sha256="unused",
+            story_file_sha256=hl.sha256(repo / story_rel),
+            dependencies=(),
+            generated_at="2026-01-01T00:00:00+00:00",
+            branch="loop/story-9-9-test-story",
+            constraints=(),
+        )
+
+    def test_unchanged_story_passes(self, git_repo: Path) -> None:
+        story_rel = "_bmad-output/implementation-artifacts/9-9-test-story.md"
+        _write(git_repo, story_rel, "# Story\n\nOriginal acceptance criteria.\n")
+        packet = self._packet(git_repo, story_rel)
+        hl.verify_story_untouched(packet, root=git_repo)
+
+    def test_uncommitted_story_edit_fails_closed(self, git_repo: Path) -> None:
+        story_rel = "_bmad-output/implementation-artifacts/9-9-test-story.md"
+        _write(git_repo, story_rel, "# Story\n\nOriginal acceptance criteria.\n")
+        packet = self._packet(git_repo, story_rel)
+        # Codex edits its own authoritative story without committing.
+        _write(git_repo, story_rel, "# Story\n\nWeakened acceptance criteria.\n")
+        with pytest.raises(hl.LoopError, match="changed during Codex execution"):
+            hl.verify_story_untouched(packet, root=git_repo)
+
+    def test_committed_story_edit_fails_closed(self, git_repo: Path) -> None:
+        story_rel = "_bmad-output/implementation-artifacts/9-9-test-story.md"
+        _write(git_repo, story_rel, "# Story\n\nOriginal acceptance criteria.\n")
+        packet = self._packet(git_repo, story_rel)
+        # Codex commits an edit to the story it must treat as read-only.
+        _write(git_repo, story_rel, "# Story\n\nCodex-rewritten acceptance criteria.\n")
+        _run_git(git_repo, "add", story_rel)
+        _run_git(git_repo, "commit", "-q", "-m", "tamper with story")
+        with pytest.raises(hl.LoopError, match="changed during Codex execution"):
+            hl.verify_story_untouched(packet, root=git_repo)
+
+    def test_missing_story_fails_closed(self, git_repo: Path) -> None:
+        story_rel = "_bmad-output/implementation-artifacts/9-9-test-story.md"
+        story_path = _write(git_repo, story_rel, "# Story\n")
+        packet = self._packet(git_repo, story_rel)
+        story_path.unlink()
+        with pytest.raises(hl.LoopError, match="missing after execution"):
+            hl.verify_story_untouched(packet, root=git_repo)


### PR DESCRIPTION
## What changed

- added a repository-level agent execution contract in `AGENTS.md`
- added a bounded one-story Claude → Codex controller at `agent-system/handoff_loop.py`
- added the Codex worker prompt and operating documentation
- added local runtime artifacts under `.agent-handoff/` and ignored them from Git

## Operating behavior

The controller reads the existing BMAD `sprint-status.yaml`, selects only stories that are `ready-for-dev`, `loop_eligible: true`, and dependency-clear, then creates a SHA-bound handoff and invokes `codex exec --ephemeral` on a fresh `loop/story-*` branch.

It rejects changes to protected orchestration files, runs the full backend/frontend/build validation suite, stops after one story, and leaves the result for independent Claude review. It never merges and never edits `loop_eligible`.

## Validation

The branch was created directly through GitHub, so the local controller could not be executed in this environment. CI should validate repository compatibility; the first local use should begin with:

```bash
python agent-system/handoff_loop.py status
python agent-system/handoff_loop.py prepare
```

before allowing a live `run`.

## Human review focus

- confirm the story dependency parser matches current BMAD prerequisite wording
- confirm `codex exec --ephemeral -` behavior with the installed Codex CLI on Windows
- confirm the desired separation between Codex committing locally and Claude pushing/opening the story PR
